### PR TITLE
Fix left panel height in Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,7 @@
 			background-color:white;
 			left: 5px;
 			padding-bottom: 40px;
+			height:100%;
 		}
 	</style>
 </head>


### PR DESCRIPTION
In Firefox 32 the manual panel does not have full height. I added `height:100%` to div.leftpanel. This fixes the height in Firefox and seems to not affect Chrome. I haven't tested any other browsers.
