### PR TITLE
Added numeric formatting options for decompiled output.

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,15 +157,28 @@
 				</table>
 			</div>
 
-			<div id="bintools" class="rightpanel" style="display:none">
-				<h3>Binary Tools</h3>
-				Note that decompilation can be slow.<br/>
-				Enter a byte array:<br/>
-				<textarea id="decompileInput" rows="6" cols="40">[0xD0, 0x15, 0x70, 0x04, 0x40, 0x40, 0x71, 0x05, 0x40, 0x40, 0x60, 0x00, 0x12, 0x00]</textarea><br/>
-				<button type="button" onclick="decompileStart()">Decompile</button>
-				<button type="button" onclick="decompileRun()">Run</button>
-				<button type="button" onclick="decompileFile()">Open File...</button>
-				<input type="file" id="fileinput" onchange="decompileRequestLoad()" style="display:none">
+            <div id="bintools" class="rightpanel" style="display:none">
+                <h3>Binary Tools</h3>
+                Note that decompilation can be slow.<br/>
+                Enter a byte array:<br/>
+                <textarea id="decompileInput" rows="6" cols="40">[0xD0, 0x15, 0x70, 0x04, 0x40, 0x40, 0x71, 0x05, 0x40, 0x40, 0x60, 0x00, 0x12, 0x00]</textarea><br/>
+                <button type="button" onclick="decompileStart()">Decompile</button>
+                <button type="button" onclick="decompileRun()">Run</button>
+                <button type="button" onclick="decompileFile()">Open File...</button>
+                <input type="file" id="fileinput" onchange="decompileRequestLoad()" style="display:none">
+                <h3>Decompiler Options</h3>
+                <select id="numericFormat" onchange="setNumericFormat();">
+                    <option value='default'>Numeric Format</option>
+                    <option value='hex'>Hexadecimal</option>
+                    <option value='dec'>Decimal</option>
+                    <option value='bin'>Binary</option>
+                </select>
+                <table>
+                    <tr>
+                        <td><input type="checkbox" id="maskOverride" onchange="setMaskFormatOverride();"></td>
+                        <td>Format the numeric operand of <tt>random n</tt> as binary</td>
+                    </tr>
+                </table>
 			</div>
 
 			<div id="audiotools" class="rightpanel" style="display:none">

--- a/index.html
+++ b/index.html
@@ -157,28 +157,28 @@
 				</table>
 			</div>
 
-            <div id="bintools" class="rightpanel" style="display:none">
-                <h3>Binary Tools</h3>
-                Note that decompilation can be slow.<br/>
-                Enter a byte array:<br/>
-                <textarea id="decompileInput" rows="6" cols="40">[0xD0, 0x15, 0x70, 0x04, 0x40, 0x40, 0x71, 0x05, 0x40, 0x40, 0x60, 0x00, 0x12, 0x00]</textarea><br/>
-                <button type="button" onclick="decompileStart()">Decompile</button>
-                <button type="button" onclick="decompileRun()">Run</button>
-                <button type="button" onclick="decompileFile()">Open File...</button>
-                <input type="file" id="fileinput" onchange="decompileRequestLoad()" style="display:none">
-                <h3>Decompiler Options</h3>
-                <select id="numericFormat" onchange="setNumericFormat();">
-                    <option value='default'>Numeric Format</option>
-                    <option value='hex'>Hexadecimal</option>
-                    <option value='dec'>Decimal</option>
-                    <option value='bin'>Binary</option>
-                </select>
-                <table>
-                    <tr>
-                        <td><input type="checkbox" id="maskOverride" onchange="setMaskFormatOverride();"></td>
-                        <td>Format the numeric operand of <tt>random n</tt> as binary</td>
-                    </tr>
-                </table>
+			<div id="bintools" class="rightpanel" style="display:none">
+				<h3>Binary Tools</h3>
+				Note that decompilation can be slow.<br/>
+				Enter a byte array:<br/>
+				<textarea id="decompileInput" rows="6" cols="40">[0xD0, 0x15, 0x70, 0x04, 0x40, 0x40, 0x71, 0x05, 0x40, 0x40, 0x60, 0x00, 0x12, 0x00]</textarea><br/>
+				<button type="button" onclick="decompileStart()">Decompile</button>
+				<button type="button" onclick="decompileRun()">Run</button>
+				<button type="button" onclick="decompileFile()">Open File...</button>
+				<input type="file" id="fileinput" onchange="decompileRequestLoad()" style="display:none">
+				<h3>Decompiler Options</h3>
+				<select id="numericFormat" onchange="setNumericFormat();">
+					<option value='default'>Numeric Format</option>
+					<option value='hex'>Hexadecimal</option>
+					<option value='dec'>Decimal</option>
+					<option value='bin'>Binary</option>
+				</select>
+				<table>
+					<tr>
+						<td><input type="checkbox" id="maskOverride" onchange="setMaskFormatOverride();"></td>
+						<td>Format the numeric operand of <tt>random n</tt> as binary</td>
+					</tr>
+				</table>
 			</div>
 
 			<div id="audiotools" class="rightpanel" style="display:none">

--- a/js/decompiler.js
+++ b/js/decompiler.js
@@ -33,11 +33,6 @@ var lnames      = {}; // map<address, name>
 var snames      = {}; // map<address, name>
 var nnames      = {}; // map<address, name>
 
-function hexFormat(num) {
-	var hex = num.toString(16).toUpperCase();
-	return "0x" + ((hex.length > 1) ? hex : "0" + hex);
-}
-
 function formatInstruction(a, nn) {
 	// convert a pair of bytes representing an instruction
 	// into a string of the equivalent octo statement.
@@ -51,8 +46,8 @@ function formatInstruction(a, nn) {
 	var vx = "v" + (x.toString(16).toUpperCase());
 	var vy = "v" + (y.toString(16).toUpperCase());
 
-	if (a  == 0x00 && y == 0xC) { return "scroll-down " + n; } // schip
-	if (a  == 0x00 && y == 0xD) { return "scroll-up " + n; } // xo-chip
+	if (a  == 0x00 && y == 0xC) { return "scroll-down " + numericFormat(n); } // schip
+	if (a  == 0x00 && y == 0xD) { return "scroll-up " + numericFormat(n); } // xo-chip
 	if (op == 0x00E0)           { return "clear"; }
 	if (op == 0x00EE)           { return "return"; }
 	if (op == 0x00FB)           { return "scroll-right"; } // schip
@@ -62,13 +57,13 @@ function formatInstruction(a, nn) {
 	if (op == 0x00FF)           { return "hires"; } // schip
 	if (o == 0x1)               { return "jump " + lnames[nnn]; }
 	if (o == 0x2)               { return snames[nnn]; }
-	if (o == 0x3)               { return "if " + vx + " != " + nn + " then"; }
-	if (o == 0x4)               { return "if " + vx + " == " + nn + " then"; }
+	if (o == 0x3)               { return "if " + vx + " != " + numericFormat(nn) + " then"; }
+	if (o == 0x4)               { return "if " + vx + " == " + numericFormat(nn) + " then"; }
 	if (o == 0x5 && n == 0x0)   { return "if " + vx + " != " + vy + " then"; }
 	if (o == 0x5 && n == 0x2)   { return "save " + vx + " - " + vy; } // xo-chip
 	if (o == 0x5 && n == 0x3)   { return "load " + vx + " - " + vy; } // xo-chip
-	if (o == 0x6)               { return vx + " := " + nn; }
-	if (o == 0x7)               { return vx + " += " + nn; }
+	if (o == 0x6)               { return vx + " := " + numericFormat(nn); }
+	if (o == 0x7)               { return vx + " += " + numericFormat(nn); }
 	if (o == 0x8 && n == 0x0)   { return vx + " := " + vy; }
 	if (o == 0x8 && n == 0x1)   { return vx + " |= " + vy; }
 	if (o == 0x8 && n == 0x2)   { return vx + " &= " + vy; }
@@ -81,8 +76,8 @@ function formatInstruction(a, nn) {
 	if (o == 0x9 && n == 0x0)   { return "if " + vx + " == " + vy + " then"; }
 	if (o == 0xA)               { return "i := " + lnames[nnn]; }
 	if (o == 0xB)               { return "jump0 " + lnames[nnn]; }
-	if (o == 0xC)               { return vx + " := random " + nn; }
-	if (o == 0xD)               { return "sprite " + vx + " " + vy + " " + n; }
+	if (o == 0xC)               { return vx + " := random " + maskFormat(nn, 2); }
+	if (o == 0xD)               { return "sprite " + vx + " " + vy + " " + numericFormat(n); }
 	if (o == 0xE && nn == 0x9E) { return "if " + vx + " -key then"; }
 	if (o == 0xE && nn == 0xA1) { return "if " + vx + " key then"; }
 	if (op == 0xF000)           { return "i := long "; }
@@ -107,7 +102,7 @@ function formatInstruction(a, nn) {
 	if (o == 0x0) {
 		return "native " + ((nnn in nnames) ? nnames[nnn] : hexFormat(nnn));
 	}
-	return hexFormat(a) + " " + hexFormat(nn) + " # bad opcode?"
+    return hexFormat(a) + " " + hexFormat(nn) + " # bad opcode?";
 }
 
 function formatNative(addr, prefix) {
@@ -657,7 +652,7 @@ function analyze(rom, quirks) {
 }
 
 function formatProgram(programSize) {
-	var ret = "";
+    var ret = "";
 	if (SHIFT_QUIRKS) {
 		ret += "# analyzed with shifts that modify vx in place and ignore vy.\n";
 	}
@@ -678,7 +673,7 @@ function formatProgram(programSize) {
 			var addr = parseInt(a);
 			if (addr < 0x200 || addr >= 0x200 + programSize) {
 				dest[addr] = true;
-				ret += (":const " + names[addr] + " " + addr + "\n");
+				ret += (":const " + names[addr] + " " + numericFormat(addr) + "\n");
 			}
 		}
 	}

--- a/js/decompiler.js
+++ b/js/decompiler.js
@@ -102,7 +102,7 @@ function formatInstruction(a, nn) {
 	if (o == 0x0) {
 		return "native " + ((nnn in nnames) ? nnames[nnn] : hexFormat(nnn));
 	}
-    return hexFormat(a) + " " + hexFormat(nn) + " # bad opcode?";
+	return hexFormat(a) + " " + hexFormat(nn) + " # bad opcode?";
 }
 
 function formatNative(addr, prefix) {
@@ -652,7 +652,7 @@ function analyze(rom, quirks) {
 }
 
 function formatProgram(programSize) {
-    var ret = "";
+	var ret = "";
 	if (SHIFT_QUIRKS) {
 		ret += "# analyzed with shifts that modify vx in place and ignore vy.\n";
 	}

--- a/js/emulator.js
+++ b/js/emulator.js
@@ -72,17 +72,19 @@ var bigfont = [
 function Emulator() {
 
 	// persistent configuration settings
-	this.ticksPerFrame   = 20;
-	this.fillColor       = "#FFCC00";
-	this.fillColor2      = "#FF6600";
-	this.blendColor      = "#662200";
-	this.backColor       = "#996600";
-	this.buzzColor       = "#FFAA00";
-	this.quietColor      = "#000000";
-	this.shiftQuirks     = false;
-	this.loadStoreQuirks = false;
-	this.vfOrderQuirks   = false;
-	this.enableXO        = false;
+	this.ticksPerFrame      = 20;
+	this.fillColor          = "#FFCC00";
+	this.fillColor2         = "#FF6600";
+	this.blendColor         = "#662200";
+	this.backColor          = "#996600";
+	this.buzzColor          = "#FFAA00";
+	this.quietColor         = "#000000";
+	this.shiftQuirks        = false;
+	this.loadStoreQuirks    = false;
+	this.vfOrderQuirks      = false;
+	this.enableXO           = false;
+	this.maskFormatOverride = true;
+    this.numericFormatStr   = "default";
 
 	// interpreter state
 	this.p  = [[],[]];  // pixels

--- a/js/emulator.js
+++ b/js/emulator.js
@@ -84,7 +84,7 @@ function Emulator() {
 	this.vfOrderQuirks      = false;
 	this.enableXO           = false;
 	this.maskFormatOverride = true;
-    this.numericFormatStr   = "default";
+	this.numericFormatStr   = "default";
 
 	// interpreter state
 	this.p  = [[],[]];  // pixels

--- a/js/octo.js
+++ b/js/octo.js
@@ -8,63 +8,43 @@
 
 var zeroes = "00000000";
 
-function maskFormat(mask)
-{
-	if (emulator.maskFormatOverride)
-	{
-		return binaryFormat(mask);
-	}
-	else
-	{
-		return numericFormat(mask);
-	}
+function maskFormat(mask) {
+	if (emulator.maskFormatOverride) { return binaryFormat(mask);  }
+	else                             { return numericFormat(mask); }
 }
 
-function numericFormat(num)
-{
-	if (emulator.numericFormatStr == "dec")
-	{
-		return decimalFormat(num);
-	}
-	else if (emulator.numericFormatStr == "bin")
-	{
-		return binaryFormat(num);
-	}
-	else if (emulator.numericFormatStr == "hex")
-	{
-		return hexFormat(num);
-	}
+function numericFormat(num) {
+	if (emulator.numericFormatStr == "dec")      { return decimalFormat(num); } 
+	else if (emulator.numericFormatStr == "bin") { return binaryFormat(num);  }
+	else if (emulator.numericFormatStr == "hex") { return hexFormat(num);     }
 
 	return hexFormat(num);
 }
 
 
-function decimalFormat(num)
-{
+function decimalFormat(num) {
 	var dec = num.toString(10);
 	return dec;
 }
 
 
 function hexFormat(num) {
-	var hex = num.toString(16).toUpperCase();
+	var hex  = num.toString(16).toUpperCase();
 	var pad0 = zeroPad(hex.length, 2);
 	return "0x" + pad0 + hex;
 }
 
-function binaryFormat(num)
-{
-	var bin = num.toString(2);
+function binaryFormat(num) {
+	var bin  = num.toString(2);
 	var pad0 = zeroPad(bin.length, 8);
 	return "0b" + pad0 + bin;
 }
 
 function zeroPad(strLen, byteLength) {
 	var dif = strLen % byteLength;
-	if (dif == 0)
-		return "";
+	if (dif == 0) { return ""; }
 
-	var len = byteLength - dif;
+	var len  = byteLength - dif;
 	var pad0 = zeroes.substr(0, len);
 	return pad0;
 }

--- a/js/octo.js
+++ b/js/octo.js
@@ -10,39 +10,39 @@ var zeroes = "00000000";
 
 function maskFormat(mask)
 {
-    if (emulator.maskFormatOverride)
-    {
-        return binaryFormat(mask);
-    }
-    else
-    {
-        return numericFormat(mask);
-    }
+	if (emulator.maskFormatOverride)
+	{
+		return binaryFormat(mask);
+	}
+	else
+	{
+		return numericFormat(mask);
+	}
 }
 
 function numericFormat(num)
 {
-    if (emulator.numericFormatStr == "dec")
-    {
-        return decimalFormat(num);
-    }
-    else if (emulator.numericFormatStr == "bin")
-    {
-        return binaryFormat(num);
-    }
-    else if (emulator.numericFormatStr == "hex")
-    {
-        return hexFormat(num);
-    }
+	if (emulator.numericFormatStr == "dec")
+	{
+		return decimalFormat(num);
+	}
+	else if (emulator.numericFormatStr == "bin")
+	{
+		return binaryFormat(num);
+	}
+	else if (emulator.numericFormatStr == "hex")
+	{
+		return hexFormat(num);
+	}
 
-    return hexFormat(num);
+	return hexFormat(num);
 }
 
 
 function decimalFormat(num)
 {
-    var dec = num.toString(10);
-    return dec;
+	var dec = num.toString(10);
+	return dec;
 }
 
 
@@ -55,18 +55,18 @@ function hexFormat(num) {
 function binaryFormat(num)
 {
 	var bin = num.toString(2);
-    var pad0 = zeroPad(bin.length, 8);
-    return "0b" + pad0 + bin;
+	var pad0 = zeroPad(bin.length, 8);
+	return "0b" + pad0 + bin;
 }
 
 function zeroPad(strLen, byteLength) {
-    var dif = strLen % byteLength;
-    if (dif == 0)
-        return "";
+	var dif = strLen % byteLength;
+	if (dif == 0)
+		return "";
 
-    var len = byteLength - dif;
-    var pad0 = zeroes.substr(0, len);
-    return pad0;
+	var len = byteLength - dif;
+	var pad0 = zeroes.substr(0, len);
+	return pad0;
 }
 
 
@@ -137,9 +137,9 @@ function runRom(rom) {
 	if (intervalHandle != null) { reset(); }
 	emulator.exitVector = reset;
 	emulator.importFlags = function() { return JSON.parse(localStorage.getItem("octoFlagRegisters")); }
-    emulator.exportFlags = function(flags) { localStorage.setItem("octoFlagRegisters", JSON.stringify(flags)); }
-    emulator.buzzTrigger = function(ticks) { playPattern(ticks, emulator.pattern); }
-    emulator.init(rom);
+	emulator.exportFlags = function(flags) { localStorage.setItem("octoFlagRegisters", JSON.stringify(flags)); }
+	emulator.buzzTrigger = function(ticks) { playPattern(ticks, emulator.pattern); }
+	emulator.init(rom);
 	audioSetup();
 	document.getElementById("emulator").style.display = "inline";
 	document.getElementById("emulator").style.backgroundColor = emulator.quietColor;
@@ -174,7 +174,7 @@ function share() {
 			window.location.href = window.location.href.replace(/(index.html|\?gist=.*)*$/, 'index.html?gist=' + result.id);
 		}
 	}
-    var prog = document.getElementById("input").value;
+	var prog = document.getElementById("input").value;
 	var options = JSON.stringify({
 		"tickrate"        : emulator.ticksPerFrame,
 		"fillColor"       : emulator.fillColor,
@@ -223,7 +223,7 @@ function runGist() {
 			run();
 		}
 	}
-    xhr.send();
+	xhr.send();
 }
 
 ////////////////////////////////////
@@ -786,19 +786,19 @@ function clearBreakpoint() {
 ////////////////////////////////////
 
 function setMaskFormatOverride() {
-    var check = document.getElementById("maskOverride");
-    emulator.maskFormatOverride = check.checked;
+	var check = document.getElementById("maskOverride");
+	emulator.maskFormatOverride = check.checked;
 }
 
 function setNumericFormat() {
-    var val = document.getElementById("numericFormat").value;
-    emulator.numericFormatStr = val.length < 1 ? "default"  : val;
+	var val = document.getElementById("numericFormat").value;
+	emulator.numericFormatStr = val.length < 1 ? "default"  : val;
 }
 
 function toggleBinaryTools() {
-    var tools = document.getElementById("bintools");
-    document.getElementById("maskOverride").checked = emulator.maskFormatOverride;
-    document.getElementById("numericFormat").value = emulator.numericFormatStr;
+	var tools = document.getElementById("bintools");
+	document.getElementById("maskOverride").checked = emulator.maskFormatOverride;
+	document.getElementById("numericFormat").value = emulator.numericFormatStr;
 	if (tools.style.display == "none") {
 		tools.style.display = "inline";
 		document.getElementById("options").style.display = "none";
@@ -903,7 +903,7 @@ function loadExample() {
 		var decoded = window.atob(stripped);
 		document.getElementById("input").value = decoded;
 	}
-    xhr.send();
+	xhr.send();
 }
 
 function listExamples() {
@@ -922,7 +922,7 @@ function listExamples() {
 			document.getElementById("examples").add(option);
 		}
 	}
-    xhr.send();
+	xhr.send();
 }
 
 listExamples();

--- a/js/octo.js
+++ b/js/octo.js
@@ -6,10 +6,69 @@
 //
 ////////////////////////////////////
 
+var zeroes = "00000000";
+
+function maskFormat(mask)
+{
+    if (emulator.maskFormatOverride)
+    {
+        return binaryFormat(mask);
+    }
+    else
+    {
+        return numericFormat(mask);
+    }
+}
+
+function numericFormat(num)
+{
+    if (emulator.numericFormatStr == "dec")
+    {
+        return decimalFormat(num);
+    }
+    else if (emulator.numericFormatStr == "bin")
+    {
+        return binaryFormat(num);
+    }
+    else if (emulator.numericFormatStr == "hex")
+    {
+        return hexFormat(num);
+    }
+
+    return hexFormat(num);
+}
+
+
+function decimalFormat(num)
+{
+    var dec = num.toString(10);
+    return dec;
+}
+
+
 function hexFormat(num) {
 	var hex = num.toString(16).toUpperCase();
-	return "0x" + ((hex.length > 1) ? hex : "0" + hex);
+	var pad0 = zeroPad(hex.length, 2);
+	return "0x" + pad0 + hex;
 }
+
+function binaryFormat(num)
+{
+	var bin = num.toString(2);
+    var pad0 = zeroPad(bin.length, 8);
+    return "0b" + pad0 + bin;
+}
+
+function zeroPad(strLen, byteLength) {
+    var dif = strLen % byteLength;
+    if (dif == 0)
+        return "";
+
+    var len = byteLength - dif;
+    var pad0 = zeroes.substr(0, len);
+    return pad0;
+}
+
 
 function display(rom) {
 	return "[" + (rom.map(hexFormat).join(", ")) + "]";
@@ -78,9 +137,9 @@ function runRom(rom) {
 	if (intervalHandle != null) { reset(); }
 	emulator.exitVector = reset;
 	emulator.importFlags = function() { return JSON.parse(localStorage.getItem("octoFlagRegisters")); }
-	emulator.exportFlags = function(flags) { localStorage.setItem("octoFlagRegisters", JSON.stringify(flags)); }
-	emulator.buzzTrigger = function(ticks) { playPattern(ticks, emulator.pattern); }
-	emulator.init(rom);
+    emulator.exportFlags = function(flags) { localStorage.setItem("octoFlagRegisters", JSON.stringify(flags)); }
+    emulator.buzzTrigger = function(ticks) { playPattern(ticks, emulator.pattern); }
+    emulator.init(rom);
 	audioSetup();
 	document.getElementById("emulator").style.display = "inline";
 	document.getElementById("emulator").style.backgroundColor = emulator.quietColor;
@@ -115,7 +174,7 @@ function share() {
 			window.location.href = window.location.href.replace(/(index.html|\?gist=.*)*$/, 'index.html?gist=' + result.id);
 		}
 	}
-	var prog = document.getElementById("input").value;
+    var prog = document.getElementById("input").value;
 	var options = JSON.stringify({
 		"tickrate"        : emulator.ticksPerFrame,
 		"fillColor"       : emulator.fillColor,
@@ -164,7 +223,7 @@ function runGist() {
 			run();
 		}
 	}
-	xhr.send();
+    xhr.send();
 }
 
 ////////////////////////////////////
@@ -726,8 +785,20 @@ function clearBreakpoint() {
 //
 ////////////////////////////////////
 
+function setMaskFormatOverride() {
+    var check = document.getElementById("maskOverride");
+    emulator.maskFormatOverride = check.checked;
+}
+
+function setNumericFormat() {
+    var val = document.getElementById("numericFormat").value;
+    emulator.numericFormatStr = val.length < 1 ? "default"  : val;
+}
+
 function toggleBinaryTools() {
-	var tools = document.getElementById("bintools");
+    var tools = document.getElementById("bintools");
+    document.getElementById("maskOverride").checked = emulator.maskFormatOverride;
+    document.getElementById("numericFormat").value = emulator.numericFormatStr;
 	if (tools.style.display == "none") {
 		tools.style.display = "inline";
 		document.getElementById("options").style.display = "none";
@@ -832,7 +903,7 @@ function loadExample() {
 		var decoded = window.atob(stripped);
 		document.getElementById("input").value = decoded;
 	}
-	xhr.send();
+    xhr.send();
 }
 
 function listExamples() {
@@ -851,7 +922,7 @@ function listExamples() {
 			document.getElementById("examples").add(option);
 		}
 	}
-	xhr.send();
+    xhr.send();
 }
 
 listExamples();

--- a/octo
+++ b/octo
@@ -110,8 +110,7 @@ else if (extractFlag("--bin")) { options['numericFormat'] = 'bin'; }
 if (process.argv.length != 3 && process.argv.length != 4 && process.argv.length != 5 && process.argv.length != 6 ) { printUsage(); }
 var sourceFile = process.argv[2];
 var destFile   = process.argv[3];
-console.log(sourceFile);
-console.log(destFile);
+
 var decompiledText = "";
 
 if (decompileFlag) {

--- a/octo
+++ b/octo
@@ -5,6 +5,50 @@ var compiler   = require('./js/compiler');
 var decompiler = require('./js/decompiler');
 var fs         = require('fs');
 
+
+var zeroes = "00000000";
+
+global.maskFormat = function (mask) {
+	if (!options['numericMask']) { return binaryFormat(mask);  }
+	else                         { return numericFormat(mask); }
+}
+
+global.numericFormat = function (num) {
+	if (options['numericFormat'] == "dec")      { return decimalFormat(num); } 
+	else if (options['numericFormat'] == "bin") { return binaryFormat(num);  }
+	else if (options['numericFormat'] == "hex") { return hexFormat(num);     }
+
+	return hexFormat(num);
+}
+
+global.decimalFormat = function (num) {
+	var dec = num.toString(10);
+	return dec;
+}
+
+global.hexFormat = function (num) {
+	var hex  = num.toString(16).toUpperCase();
+	var pad0 = zeroPad(hex.length, 2);
+	return "0x" + pad0 + hex;
+}
+
+global.binaryFormat = function (num) {
+	var bin  = num.toString(2);
+	var pad0 = zeroPad(bin.length, 8);
+	return "0b" + pad0 + bin;
+}
+
+function zeroPad(strLen, byteLength) {
+	var dif = strLen % byteLength;
+	if (dif == 0) { return ""; }
+
+	var len  = byteLength - dif;
+	var pad0 = zeroes.substr(0, len);
+	return pad0;
+}
+
+
+
 function extractFlag(name) {
 	var index = process.argv.indexOf(name);
 	if (index == -1) { return false; }
@@ -47,7 +91,7 @@ function decompileFile(src, dst) {
 }
 
 function printUsage() {
-	console.log("usage: octo [--decompile] [--roundtrip] [--qshift] [--qloadstore] [--qvforder] <source> [<destination>]");
+	console.log("usage: octo [--decompile | --roundtrip] [--hex | --dec | --bin] [--numMask] [--qshift] [--qloadstore] [--qvforder] <source> [<destination>]");
 	process.exit(1);
 }
 
@@ -55,13 +99,19 @@ var options = {};
 options['shiftQuirks'    ] = extractFlag("--qshift");
 options['loadStoreQuirks'] = extractFlag("--qloadstore");
 options['vfOrderQuirks'  ] = extractFlag("--qvforder");
+options['numericMask'    ] = extractFlag("--numMask") 
 var decompileFlag = extractFlag("--decompile");
 var roundTripFlag = extractFlag("--roundtrip");
 
-if (process.argv.length != 3 && process.argv.length != 4) { printUsage(); }
+if(extractFlag("--hex"))      { options['numericFormat'] = 'hex'; }
+else if(extractFlag("--dec")) { options['numericFormat'] = 'dec'; } 
+else if (extractFlag("--bin")) { options['numericFormat'] = 'bin'; }
+
+if (process.argv.length != 3 && process.argv.length != 4 && process.argv.length != 5 && process.argv.length != 6 ) { printUsage(); }
 var sourceFile = process.argv[2];
 var destFile   = process.argv[3];
-
+console.log(sourceFile);
+console.log(destFile);
 var decompiledText = "";
 
 if (decompileFlag) {
@@ -78,13 +128,7 @@ if (roundTripFlag) {
 		decompiledText = decompiler.formatProgram(startBinary.length);
 	}
 	var endBinary = compile(decompiledText);
-
-	function hexFormat(num) {
-		if (typeof num == "undefined") { return "(none)"; }
-		var hex = num.toString(16).toUpperCase();
-		return "0x" + ((hex.length > 1) ? hex : "0" + hex);
-	}
-
+	
 	var mismatch = false;
 	for(var x = 0; x < Math.max(startBinary.length, endBinary.length); x++) {
 		var mishere = (startBinary[x] != endBinary[x]);


### PR DESCRIPTION
I changed several of the default string conversions to use a new method that provides hex, decimal and binary formats based on user selection. Hex is set as the new default format. Hex and binary values are zero padded to full byte width.

I also added an option to override the default format for random n  to output the mask formatted to binary. Enabled by default.
