### PR TITLE
A quick fix for issue 13.  

### DIFF
--- a/js/decompiler.js
+++ b/js/decompiler.js
@@ -609,11 +609,13 @@ function analyzeWork() {
 
 	for(var x = 0; x < children.length; x++) {
 		var child = children[x];
-		if (child == here) {
-			continue;
-		}
+
 		var isReturn = (program[child] == 0x00 && program[child+1] == 0xEE);
 
+		if (child == here && isReturn) { 
+			continue;
+		}
+	
 		if ((typeof reaching[child]) == "undefined") {
 			// always explore fresh nodes:
 			reaching[child] = copyReachingSet(output);

--- a/js/decompiler.js
+++ b/js/decompiler.js
@@ -609,6 +609,8 @@ function analyzeWork() {
 
 	for(var x = 0; x < children.length; x++) {
 		var child = children[x];
+		if(child == here)
+			continue;
 		var isReturn = (program[child] == 0x00 && program[child+1] == 0xEE);
 
 		if ((typeof reaching[child]) == "undefined") {

--- a/js/decompiler.js
+++ b/js/decompiler.js
@@ -609,8 +609,9 @@ function analyzeWork() {
 
 	for(var x = 0; x < children.length; x++) {
 		var child = children[x];
-		if(child == here)
+		if (child == here) {
 			continue;
+		}
 		var isReturn = (program[child] == 0x00 && program[child+1] == 0xEE);
 
 		if ((typeof reaching[child]) == "undefined") {


### PR DESCRIPTION
Does not attempt to stop a return address from getting itself as a child, but ends the infinite recursion.

There may be a better solution, but the decompile completes and the output looks good.
