### PR TITLE
Proposed change to the way "i :=" works

### DIFF
--- a/js/emulator.js
+++ b/js/emulator.js
@@ -429,7 +429,7 @@ function Emulator() {
 			case 0x7: this.v[x] = (this.v[x] + nn) & 0xFF;          break;
 			case 0x8: this.math(x, y, n);                           break;
 			case 0x9: if (this.v[x] != this.v[y]) { this.pc += 2; } break;
-			case 0xA: this.i = (this.i & 0xF000) | nnn;             break;
+			case 0xA: this.i = nnn;                                 break;
 			case 0xB: this.pc = nnn + this.v[0];                    break;
 			case 0xC: this.v[x] = (Math.random()*255)&nn;           break;
 			case 0xD: this.sprite(this.v[x], this.v[y], n);         break;


### PR DESCRIPTION
Minimal test-case: http://johnearnest.github.io/Octo/index.html?gist=fb284783560e65edb8f9 

After setting "i" to point somewhere that requires using a long memory reference, when you then set it to point somewhere else without using the special long memory reference code, it won't change the leftmost byte of its address. This causes it to not actually point where you requested it to.

I'm not sure if this is intended behaviour or not but I ran into it when making civ8n and it confused me for a bit. It seems intended based on the code but I thought I'd try this whole forking/pull request thing anyway.
