### PR TITLE
Implemented timer-aware audio buffers scheduling

### DIFF
--- a/js/emulator.js
+++ b/js/emulator.js
@@ -113,7 +113,7 @@ function Emulator() {
 	this.exitVector  = function() {}                                   // fired by 'exit'
 	this.importFlags = function() { return [0, 0, 0, 0, 0, 0, 0, 0]; } // load persistent flags
 	this.exportFlags = function(flags) {}                              // save persistent flags
-	this.buzzTrigger = function(ticks) {}                              // fired when buzzer played
+	this.buzzTrigger = function(ticks, remainingTicks) {}                              // fired when buzzer played
 
 	this.init = function(rom) {
 		// initialize memory
@@ -200,7 +200,7 @@ function Emulator() {
 			case 0x07: this.v[x] = this.dt; break;
 			case 0x0A: this.waiting = true; this.waitReg = x; break;
 			case 0x15: this.dt = this.v[x]; break;
-			case 0x18: this.st = this.v[x]; this.buzzTrigger(this.v[x]); break;
+			case 0x18: this.buzzTrigger(this.v[x], this.st); this.st = this.v[x]; break;
 			case 0x1E: this.i = (this.i + this.v[x])&0xFFFF; break;
 			case 0x29: this.i = ((this.v[x] & 0xF) * 5); break;
 			case 0x30: this.i = ((this.v[x] & 0xF) * 10 + font.length); break;

--- a/js/octo.js
+++ b/js/octo.js
@@ -121,7 +121,7 @@ function runRom(rom) {
 	emulator.exitVector = reset;
 	emulator.importFlags = function() { return JSON.parse(localStorage.getItem("octoFlagRegisters")); }
 	emulator.exportFlags = function(flags) { localStorage.setItem("octoFlagRegisters", JSON.stringify(flags)); }
-	emulator.buzzTrigger = function(ticks) { playPattern(ticks, emulator.pattern); }
+	emulator.buzzTrigger = function(ticks, remainingTicks) { playPattern(ticks, emulator.pattern, remainingTicks); }
 	emulator.init(rom);
 	audioSetup();
 	document.getElementById("emulator").style.display = "inline";

--- a/js/shared.js
+++ b/js/shared.js
@@ -132,7 +132,7 @@ function audioSetup() {
 				var written = audioData[0].write(outputData, index, size);
 				index += written;
 				if (written < size)
-					audioData.pop();
+					audioData.shift();
 			}
 
 			while(index < samples_n)

--- a/js/shared.js
+++ b/js/shared.js
@@ -136,7 +136,7 @@ function stopAudio() {
 
 var VOLUME = 0.25;
 
-function playPattern(soundLength, buffer) {
+function playPattern(soundLength, buffer, remainingTicks) {
 	if (!audio) { return; }
 
 	var samples = getResampledSize(BUFFER_SIZE)


### PR DESCRIPTION
First buffer with duration estimated in audio sample rate samples is scheduled.
Then, if buzzer reset or new audio scheduled, old buffer duration decreased and new buffer is scheduled next. Audio callback rush through buffers, filling what's possible and popping buffers from queue. 
After that we could smoothly play everything, even with large latency and buffer size. 

You could squash all commits if you'd prefer.

You could check the demo from my gist, it sounds far more listenable than before. :)
xoplayer example now plays notes with even interval without any tempo jumps. Audio in our game is improved as well. 
