### PR TITLE
Issue 18 fix - add regular expressions for numbers

### DIFF
--- a/js/compiler.js
+++ b/js/compiler.js
@@ -19,12 +19,12 @@ function parseNumber(token) {
     }
 
     // Check if this token is a valid hexadecimal number
-    if (/^0x[0-9a-f]+$/i.test(token)) {
-        return parseInt(token.slice(2), 16);
+    if (/^[+\-]?0x[0-9a-f]+$/i.test(token)) {
+        return parseInt(token, 16);
     }
 
     // Check if this token is a valid decimal number
-    if (/^[0-9]+$/.test(token)) {
+    if (/^[+\-]?[0-9]+$/.test(token)) {
         return parseInt(token, 10);
     }
 

--- a/js/compiler.js
+++ b/js/compiler.js
@@ -11,6 +11,27 @@ function parse(token) {
 	return isNaN(num) ? token : num;
 }
 
+function parseNumber(token) {
+
+    // Check if this token is a valid binary number
+    if (/^0b[01]+$/.test(token)) {
+        return parseInt(token.slice(2), 2);
+    }
+
+    // Check if this token is a valid hexadecimal number
+    if (/^0x[0-9a-f]+$/i.test(token)) {
+        return parseInt(token.slice(2), 16);
+    }
+
+    // Check if this token is a valid decimal number
+    if (/^[0-9]+$/.test(token)) {
+        return parseInt(token, 10);
+    }
+
+    return NaN;
+
+}
+
 function tokenize(text) {
 	var ret   = [];
 	var index = 0;

--- a/js/compiler.js
+++ b/js/compiler.js
@@ -7,7 +7,7 @@
 ////////////////////////////////////
 
 function parse(token) {
-	var num = (token.slice(0, 2) == "0b") ? parseInt(token.slice(2),2) : parseInt(token);
+	var num = parseNumber(token);
 	return isNaN(num) ? token : num;
 }
 

--- a/js/compiler.js
+++ b/js/compiler.js
@@ -14,8 +14,27 @@ function parse(token) {
 function parseNumber(token) {
 
     // Check if this token is a valid binary number
-    if (/^0b[01]+$/.test(token)) {
-        return parseInt(token.slice(2), 2);
+    if (/^[+\-]?0b[01]+$/.test(token)) {
+
+    	var bitstring;
+    	var isNegative = token.startsWith('-');
+
+    	// Check for any leading +/- sign character
+    	if(isNegative || token.startsWith('+')) {
+
+    		// Remove sign character and 0b- prefix
+    		bitstring = token.slice(3);
+
+    	} else {
+
+    		// Remove 0b- prefix
+    		bitstring = token.slice(2);
+
+    	}
+
+        var value = parseInt(bitstring, 2);
+        return (isNegative) ? -value : value;
+
     }
 
     // Check if this token is a valid hexadecimal number


### PR DESCRIPTION
These changes fix Issue #18.

I added a parseNumber() function that checks the given token against regular expressions for well-formed binary, hex, and decimal numbers prior to performing the conversion. There's some extra logic thrown in to make binary numbers work, since JavaScript's parseInt() function doesn't accept the 0b prefix.

I also stumbled upon another bug while fixing this issue. Prior to these commits, Octo handled negative binary numbers rather strangely. A valid negative binary number would look something like 0b-00101010, with the '-' character after the '0b' prefix. A number such as -0b00101010 would always be converted to zero. With these changes, Octo will only accept the '-' character before the '0b' prefix.
