### PR TITLE
AudioContext can exist when audio is not setup.

### DIFF
--- a/js/octo.js
+++ b/js/octo.js
@@ -1137,7 +1137,7 @@ function drawAudio() {
 
 function playAudio() {
 	// initialize sound if necessary
-	if (!audio && !audioSetup()) {
+	if (!audioSetup()) {
 		document.getElementById("audioError").innerHTML = "Your browser doesn't support HTML5 Audio!";
 		return;
 	}


### PR DESCRIPTION
!audio is redundant to !audioSetup() but was blocking the call of
audioSetup() to complete audio initialization in some cases.
