### PR TITLE
Add profiling support to the emulator.

### DIFF
--- a/js/emulator.js
+++ b/js/emulator.js
@@ -102,6 +102,7 @@ function Emulator() {
 	this.flags = [];    // semi-persistent hp48 flag vars
 	this.pattern = [];  // audio pattern buffer
 	this.plane = 1;     // graphics plane
+	this.profile_data = {};
 
 	// control/debug state
 	this.keys = {};       // track keys which are pressed
@@ -147,6 +148,7 @@ function Emulator() {
 		this.breakpoint = false;
 		this.metadata = rom;
 		this.tickCounter = 0;
+		this.profile_data = {};
 	}
 
 	this.writeCarry = function(dest, value, flag) {
@@ -299,6 +301,12 @@ function Emulator() {
 	}
 
 	this.opcode = function() {
+		// Record the PC in profiler
+		var pro = this.profile_data[this.pc];
+		if (typeof pro == 'undefined') { pro = 0; }
+		pro += 1;
+		this.profile_data[this.pc] = pro
+
 		// decode the current opcode
 		var op  = (this.m[this.pc  ] << 8) | this.m[this.pc+1];
 		var o   = (this.m[this.pc  ] >> 4) & 0x00F;

--- a/js/octo.js
+++ b/js/octo.js
@@ -856,18 +856,23 @@ function haltProfiler(breakName) {
 		}
 		if(addr < 65536) {
 			var instructions = (addr - cluster_begins) / 2;
+			var span = (addr - 2) - cluster_begins;
+			var source = getLabel(cluster_begins).trim();
+			if (span > 0) {
+				source += " +" + span;
+			}
 			compressed_profile.push( {	'begin': cluster_begins,
 																	'end': addr - 2,
 																	'ticks': tick_count,
 																	'calls': emulator.profile_data[cluster_begins],
-																	'percent': 100.0 * (tick_count / emulator.tickCounter)
+																	'percent': 100.0 * (tick_count / emulator.tickCounter),
+																	'source': source
 																});
 		}
 	}
 
 	var sort_criteria = 'percent';
 	compressed_profile.sort(function(a,b) { return (a[sort_criteria] < b[sort_criteria] ? 1 : (a[sort_criteria] > b[sort_criteria] ? -1: 0)); });
-
 
 	regdump += '<br><table class="debugger"><tr> <td>ticks</td> <td>time</td> <td>calls</td> <td>source</td> </tr>\n';
 	var lines = 0;
@@ -877,12 +882,7 @@ function haltProfiler(breakName) {
 			regdump += "<tr><td>" + entry.ticks + "</td>";
 			regdump += "<td>" + entry.percent.toFixed(2) + "%</td>";
 			regdump += "<td>" + entry.calls + "</td>";
-			var span = entry.end - entry.begin;
-			regdump += "<td>" + getLabel(entry.begin).trim();
-			if (span > 0) {
-				regdump += " +" + span;
-			}
-			regdump += "</td></tr>"
+			regdump += "<td>" + entry.source + "</td></tr>";
 		}
 	});
 	regdump += "</table>";


### PR DESCRIPTION
Each time an instruction is decoded, a count of ticks spent at the current PC is incremented. The user can press 'P' to show profiling information. The per-PC data is reduced into blocks of code
based on shared labels, so the granularity can be increased by adding additional labels to the code.

Please let me know if you would prefer any part of this done differently.
