### PR TITLE
Profiler: fix tick double-counting bug for first address in a cluster

### DIFF
--- a/js/octo.js
+++ b/js/octo.js
@@ -847,7 +847,7 @@ function haltProfiler(breakName) {
 		while (typeof emulator.profile_data[addr] == "undefined") { addr += 1; if (addr > 65535) break; }
 		if (addr > 65535) break;
 		cluster_begins = addr;
-		tick_count = emulator.profile_data[addr];
+		tick_count = 0;
 		label = getLabel(addr).split(' ')[1].replace('(', ''). replace(')', '');
 
 		while(typeof emulator.profile_data[addr] != "undefined" && getLabel(addr).split(' ')[1].replace('(', ''). replace(')', '') == label) {


### PR DESCRIPTION
Fix for #45. The first address in a cluster was being counted twice - once when found and then immediately after when adding up the ticks for the entire cluster.
