### PR TITLE
do not allow audioData queue grow after audio callback was fired

### DIFF
--- a/js/shared.js
+++ b/js/shared.js
@@ -214,6 +214,8 @@ function audioSetup() {
 			while(index < samples_n) {
 				outputData[index++] = 0;
 			}
+			while(audioData.length > 1)
+				audioData.shift();
 		}
 		audioData = [];
 		audioNode.connect(audio.destination);


### PR DESCRIPTION
This pull request fixes terrible lags in Kesha Was Biird and Jub8 games. 

Buffer of 4096 samples is about 92ms if sample rate is 44100, buzzer timer 2 is ~33ms, so you can just clean all pending audiobuffers except the latest one to catch up current audio generation position. 

The better fix should check all pending audio buffers for their durations and make sure that it's not growing more than audio processing buffer size (4096 samples). I can do it a little bit later.