### PR TITLE
Add step-out and step-over commands to the debugger

### DIFF
--- a/js/emulator.js
+++ b/js/emulator.js
@@ -146,6 +146,7 @@ function Emulator() {
 		this.waitReg = -1;
 		this.halted = false;
 		this.breakpoint = false;
+		this.stack_breakpoint = -1;
 		this.metadata = rom;
 		this.tickCounter = 0;
 		this.profile_data = {};

--- a/js/octo.js
+++ b/js/octo.js
@@ -226,6 +226,10 @@ function render() {
 			if (emulator.pc in emulator.metadata.breakpoints) {
 				haltBreakpoint(emulator.metadata.breakpoints[emulator.pc]);
 			}
+			if (emulator.r.length == emulator.stack_breakpoint) {
+				emulator.stack_breakpoint = -1;
+				haltBreakpoint("step out");
+			}
 		}
 	}
 	if (emulator.breakpoint != true) {

--- a/js/octo.js
+++ b/js/octo.js
@@ -266,7 +266,11 @@ function keyUp(event) {
 			keyElement.className = keyElement.className.replace('active', '');
 		}
 	}
+
+	// Reset emulator
 	if (event.keyCode == 27) { reset(); }
+
+	// Halt / Continue
 	if (event.keyCode == 73) { // i
 		if (emulator.breakpoint) {
 			clearBreakpoint();
@@ -275,13 +279,51 @@ function keyUp(event) {
 			haltBreakpoint("user interrupt");
 		}
 	}
+
+	// Single Step
 	if (event.keyCode == 79) { // o
 		if (emulator.breakpoint) {
 			emulator.tick();
 			renderDisplay(emulator);
-			haltBreakpoint("single stepping");
+			haltBreakpoint("step over");
 		}
 	}
+
+	// Step Out - Sets a breakpoint that will trigger when there is one less address
+	// on the stack (that is when the current subroutine returns). The current
+	// breakpoint is cleared and execution is resumed.
+	if (event.keyCode == 85) { // u
+		if (emulator.breakpoint) {
+			var stacklen = emulator.r.length;
+			if(stacklen > 0) {
+				emulator.stack_breakpoint = stacklen - 1;
+				clearBreakpoint();
+			}
+		}
+	}
+
+	// Step Over - Same as single-step unless the current instruction is a call.
+	// In that case, a stack breakpoint is set for the current stack level and
+	// execution is resumed
+	if (event.keyCode == 76) { // l
+		if (emulator.breakpoint) {
+
+			if ((emulator.m[emulator.pc] & 0xF0) == 0x20) {
+				var stacklen = emulator.r.length;
+				if(stacklen >= 0) {
+					emulator.stack_breakpoint = stacklen;
+					clearBreakpoint();
+				}
+			} else {
+				emulator.tick();
+				renderDisplay(emulator);
+				haltBreakpoint("stepping over");
+			}
+
+		}
+	}
+
+	// Display Profiler
 	if (event.keyCode == 80) { // p
 		haltProfiler("profiler");
 	}


### PR DESCRIPTION
This adds `stack_breakpoint` to the emulator state. During execution, `stack_breakpoint` is compared to the current stack length. If they are the same execution is halted and `stack_breakpoint` is cleared.

This functionality is used to add these features to the debugger:
 * Step Out: Clears the current breakpoint and runs until the current subroutine returns (that is, when the stack length becomes 1 less than the current length).
 * Step Over: The same as single stepping unless the next instruction is a call. In that case, execution resumes until the call returns (that is, the current stack level is reached once again).

I assigned 'U' to Step Out and 'L' to Step Over mostly due to their location nearby the existing keys. I also considered '9' for Step Over because it is _over_ the Step key. 

Does the codebase have a preferred way to get an answer to the question "is this opcode a call?" that I should use instead of the current mask and compare to literal?