### PR TITLE
Fix `random` never producing the value 255

### DIFF
--- a/js/emulator.js
+++ b/js/emulator.js
@@ -453,7 +453,7 @@ function Emulator() {
 			case 0x9: if (this.v[x] != this.v[y]) { this.pc += 2; } break;
 			case 0xA: this.i = nnn;                                 break;
 			case 0xB: this.jump0(nnn);                              break;
-			case 0xC: this.v[x] = (Math.random()*255)&nn;           break;
+			case 0xC: this.v[x] = (Math.random()*256)&nn;           break;
 			case 0xD: this.sprite(this.v[x], this.v[y], n);         break;
 			case 0xF: this.misc(x, nn);                             break;
 			default: haltBreakpoint("unknown opcode "+o);


### PR DESCRIPTION
The `random` function never returns the value 255.  The maximum it can produce is 254.  Below is an Octo program which demonstrates the problem.  After running it for a while the value shown should converge to 255 but before this change it stops at 254 instead.  The program can also be seen in action at http://johnearnest.github.io/Octo/index.html?gist=d42811980e30c69a235e08cb3d239a5e

```
# Generates random numbers and displays the maximum number seen so far

:const digit_width 5
:const digit_height 5

:alias digit_x v3
:alias digit_y v4
:alias max_random v6

: main
	digit_x := 1
	digit_y := 1

	# draw "000" to start
	draw_digit_no_erase
	draw_digit_no_erase
	draw_digit_no_erase

	loop
		v0 := random 255
        	if v0 > max_random then max_random := v0
	        draw
        again

: draw
	i := buf  bcd max_random

	digit_x := 1

	draw_digit
	i := buf_tens  draw_digit
	i := buf_ones  draw_digit

	# copy buf to prev_buf
	i := buf       load v2
	i := prev_buf  save v2

	return

: draw_digit
	load v0  v1 := v0
	v0 := 2  i += v0  load v0
	i := hex v0  sprite digit_x digit_y digit_height
	v0 := v1
	# fallthrough
: draw_digit_no_erase
	i := hex v0  sprite digit_x digit_y digit_height
	digit_x += digit_width

	return


: buf
	0
: buf_tens
	0
: buf_ones
	0

: prev_buf
	0 0 0
```