### PR TITLE
Use 'in' operator instead of bool casting because it's not triggered …

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
 		<button type="button" onClick="run()">Run</button>
 		<button type="button" onClick="compile()">Compile</button>
 		<button type="button" onClick="share()">Share</button>
+		<input type="file" id="sourceinput" accept='.8o' onchange="updateSource()" style="display:none">
+		<button type="button" onclick="uploadSource()">Open</button>
 		<select id="examples" onchange="loadExample()">
 			<option value="">Examples...</option>
 		</select>

--- a/js/octo.js
+++ b/js/octo.js
@@ -188,6 +188,22 @@ function share() {
 	}));
 }
 
+function uploadSource() {
+	document.getElementById("sourceinput").click();
+}
+
+function updateSource() {
+	var file = document.getElementById("sourceinput").files[0];
+	var reader = new FileReader();
+
+	reader.onload = function(event) {
+		var input  = document.getElementById("input");
+		input.value = event.target.result;
+	}
+
+	reader.readAsText(file);
+}
+
 function runGist() {
 	var xhr = new XMLHttpRequest();
 	var gistId = location.search.match(/gist=(\w+)/);

--- a/js/shared.js
+++ b/js/shared.js
@@ -28,7 +28,7 @@ function unpackOptions(emulator, options) {
 	]
 	for (var x = 0; x < flags.length; x++) {
 		var flag = flags[x];
-		if (options[flag]) { emulator[flag] = options[flag]; }
+		if (flag in options) { emulator[flag] = options[flag]; }
 	}
 }
 


### PR DESCRIPTION
…for boolean keys with 'false' value

This commit fix bug when you try to run an app with 'enableXO: false' after launching another app with 'enableXO: true' enableXO flag still will be 'true' after that