### PR TITLE
Save some CPU time by reducing number of fillRect calls/canvas updates

### DIFF
--- a/js/emulator.js
+++ b/js/emulator.js
@@ -351,7 +351,7 @@ function Emulator() {
 			var rowSize = this.hires ? 128 : 64;
 			for(var layer = 0; layer < 2; layer++) {
 				if ((this.plane & (layer+1)) == 0) { continue; }
-				for(var z = this.p[layer].length; z >= 0; z--) {
+				for(var z = this.p[layer].length - 1; z >= 0; z--) {
 					this.p[layer][z] = (z >= rowSize * n) ? this.p[layer][z - (rowSize * n)] : 0;
 				}
 			}

--- a/js/shared.js
+++ b/js/shared.js
@@ -107,10 +107,13 @@ function renderDisplay(emulator) {
 	// Canvas rendering can be expensive. Exit out early if nothing has changed.
 	// NOTE: toggling emulator.hires changes emulator.p dimensions.
 	var colors = [emulator.backColor, emulator.fillColor, emulator.fillColor2, emulator.blendColor];
-	if (c.last !== undefined
-			&& arrayEqual(c.last.p[0], emulator.p[0]) && arrayEqual(c.last.p[1], emulator.p[1])
-			&& arrayEqual(c.last.colors, colors)) {
-		return;
+	if (c.last !== undefined) {
+		if (arrayEqual(c.last.p[0], emulator.p[0]) && arrayEqual(c.last.p[1], emulator.p[1])
+				&& arrayEqual(c.last.colors, colors)) {
+			return;
+		}
+		if (c.last.p[0].length != emulator.p[0].length)
+			c.last = undefined
 	}
 	var g = c.getContext("2d");
 	getTransform(emulator, g);

--- a/js/shared.js
+++ b/js/shared.js
@@ -114,24 +114,27 @@ function renderDisplay(emulator) {
 	}
 	var g = c.getContext("2d");
 	getTransform(emulator, g);
-	var max    = emulator.hires ? 128*64      : 64*32;
-	var stride = emulator.hires ? 128         : 64;
+	var w      = emulator.hires ? 128         : 64;
+	var h      = emulator.hires ? 64          : 32;
 	var size   = emulator.hires ? scaleFactor : scaleFactor*2;
 	var lastPixels = c.last !== undefined? c.last.p: [[], []]
 
-	for(var z = 0; z < max; z++) {
-		var oldColorIdx = lastPixels[0][z] + (lastPixels[1][z] << 1);
-		var colorIdx = emulator.p[0][z] + (emulator.p[1][z] << 1);
-		if (oldColorIdx === colorIdx) {
-			continue;
+	var z = 0;
+	for(var y = 0; y < h; ++y) {
+		for(var x = 0; x < w; ++x, ++z) {
+			var oldColorIdx = lastPixels[0][z] + (lastPixels[1][z] << 1);
+			var colorIdx = emulator.p[0][z] + (emulator.p[1][z] << 1);
+			if (oldColorIdx === colorIdx) {
+				continue;
+			}
+			var color = getColor(colorIdx);
+			g.fillStyle = color;
+			g.fillRect(
+				x * size,
+				y * size,
+				size, size
+			);
 		}
-		var color = getColor(colorIdx);
-		g.fillStyle = color;
-		g.fillRect(
-			Math.floor(z%stride)*size,
-			Math.floor(z/stride)*size,
-			size, size
-		);
 	}
 
 	c.last = {

--- a/js/shared.js
+++ b/js/shared.js
@@ -112,24 +112,20 @@ function renderDisplay(emulator) {
 			&& arrayEqual(c.last.colors, colors)) {
 		return;
 	}
-	c.last = {
-		colors: colors,
-		p: [emulator.p[0].slice(), emulator.p[1].slice()]
-	};
-
 	var g = c.getContext("2d");
 	getTransform(emulator, g);
-	g.fillStyle = emulator.backgroundColor;
-	g.fillRect(0, 0, c.width, c.height);
 	var max    = emulator.hires ? 128*64      : 64*32;
 	var stride = emulator.hires ? 128         : 64;
 	var size   = emulator.hires ? scaleFactor : scaleFactor*2;
+	var lastPixels = c.last !== undefined? c.last.p: [[], []]
 
 	for(var z = 0; z < max; z++) {
-		var color = getColor(emulator.p[0][z] + (emulator.p[1][z] * 2));
-		if (color == emulator.backColor) {
-			continue;  // it's pointless to draw the background color
+		var oldColorIdx = lastPixels[0][z] + (lastPixels[1][z] << 1);
+		var colorIdx = emulator.p[0][z] + (emulator.p[1][z] << 1);
+		if (oldColorIdx === colorIdx) {
+			continue;
 		}
+		var color = getColor(colorIdx);
 		g.fillStyle = color;
 		g.fillRect(
 			Math.floor(z%stride)*size,
@@ -137,6 +133,11 @@ function renderDisplay(emulator) {
 			size, size
 		);
 	}
+
+	c.last = {
+		colors: colors,
+		p: [emulator.p[0].slice(), emulator.p[1].slice()]
+	};
 }
 
 ////////////////////////////////////

--- a/js/shared.js
+++ b/js/shared.js
@@ -119,23 +119,19 @@ function renderDisplay(emulator) {
 	var size   = emulator.hires ? scaleFactor : scaleFactor*2;
 	var lastPixels = c.last !== undefined? c.last.p: [[], []]
 
+	g.scale(size, size)
 	var z = 0;
 	for(var y = 0; y < h; ++y) {
 		for(var x = 0; x < w; ++x, ++z) {
 			var oldColorIdx = lastPixels[0][z] + (lastPixels[1][z] << 1);
 			var colorIdx = emulator.p[0][z] + (emulator.p[1][z] << 1);
-			if (oldColorIdx === colorIdx) {
-				continue;
+			if (oldColorIdx !== colorIdx) {
+				g.fillStyle = getColor(colorIdx);
+				g.fillRect(x, y, 1, 1);
 			}
-			var color = getColor(colorIdx);
-			g.fillStyle = color;
-			g.fillRect(
-				x * size,
-				y * size,
-				size, size
-			);
 		}
 	}
+	g.scale(1, 1) //restore scale to 1,1 just in case
 
 	c.last = {
 		colors: colors,


### PR DESCRIPTION
Assuming fillRect is expensive and updates are generally rare (you can only draw 8x8/16x16 sprite toggling bitplanes), I tried to fill only pixels that changed

(chrome profiler shows up to 10x performance improvement for all games I tested, heavy games don't feel sluggish anymore)

I hope @comrat should be able to test it on some tellies which are often slow. 

These are results from kesha-was-niiinja game
![image](https://user-images.githubusercontent.com/480115/32516400-1f35e52c-c3fb-11e7-97e0-504260dfa124.png)

![image](https://user-images.githubusercontent.com/480115/32516391-1a86df04-c3fb-11e7-9c49-82cd9dc1a5f7.png)
