### PR TITLE
Fix XO-chip games not sharing correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -733,7 +733,7 @@ function compile() {
     output.setValue('no output')
     c.go()
     writeBytes(output, null, c.rom)
-    const maxRom = compatSize.getValue()
+    const maxRom = emulator.maxSize
     if (c.rom.length > maxRom) {
       throw 'Rom is too large- ' + (c.rom.length-maxRom) + ' bytes over!'
     }

--- a/js/emulator.js
+++ b/js/emulator.js
@@ -87,6 +87,7 @@ function Emulator() {
 	this.vBlankQuirks       = false;
 	this.enableXO           = true;
 	this.screenRotation     = 0;
+	this.maxSize            = 3584;
 	this.maskFormatOverride = true;
 	this.numericFormatStr   = "default";
 

--- a/js/shared.js
+++ b/js/shared.js
@@ -23,12 +23,12 @@ const optionFlags = [
 	"clipQuirks",
 	"vBlankQuirks",
 	"jumpQuirks",
-	"enableXO",
 	"screenRotation",
+	"maxSize",
 ]
 function unpackOptions(emulator, options) {
 	optionFlags.forEach(x => { if (x in options) emulator[x] = options[x] })
-	emulator.enableXO = 1 // legacy option, force on
+	if (options["enableXO"]) emulator.maxSize = 65024 // legacy option
 }
 function packOptions(emulator) {
 	const r = {}

--- a/js/tool-options.js
+++ b/js/tool-options.js
@@ -2,7 +2,7 @@
 * Options
 **/
 
-const compatSize     = radioBar(document.getElementById('max-size'), 3584, updateOptions)
+const compatSize     = radioBar(document.getElementById('max-size'), 3584, setOptions)
 const compatProfile  = radioBar(document.getElementById('compatibility-profile'), 'octo', setCompatibilityProfile)
 const screenRotation = radioBar(document.getElementById('screen-rotation'), 0, x => emulator.screenRotation = +x)
 
@@ -24,23 +24,24 @@ const compatibilityFlags = {
 function setCompatibilityProfile(x) {
   const p = compatibilityProfiles[x]
   for (key in compatibilityFlags) emulator[key] = p[key]
-  compatSize.setValue(p.maxSize)
   saveLocalOptions()
   updateOptions()
 }
 function setOptions() {
   for (key in compatibilityFlags) emulator[key] = compatibilityFlags[key].getValue()
+  emulator.maxSize = compatSize.getValue()
   saveLocalOptions()
   updateOptions()
 }
 function updateOptions() {
   for (key in compatibilityFlags) compatibilityFlags[key].setValue(emulator[key])
   screenRotation.setValue(emulator.screenRotation)
+  compatSize.setValue(emulator.maxSize)
   compatProfile.setValue('none')
   for (key in compatibilityProfiles) {
     const p = compatibilityProfiles[key]
-    const same = Object.keys(p).every(x => x == 'maxSize' || emulator[x] == !!p[x])
-    if (p.maxSize == compatSize.getValue() && same) compatProfile.setValue(key)
+    const same = Object.keys(p).every(x => emulator[x] == !!p[x])
+    if (same) compatProfile.setValue(key)
   }
 
 }


### PR DESCRIPTION
The new "Maximum ROM Size" setting was never saved, which broke XO-chip games since the emulator would always default to the Octo size and fail.

This moves the setting to the emulator options, so it gets memorized by localStorage and serialized with share links correctly. It also converts the old "enableXO" option so old share links still autoplay correctly.