### PR TITLE
Fix horizontal scrolling in editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,7 +402,7 @@ input:focus { outline: none; }
 #main { flex-grow: 1; display: flex; flex-direction: row; }
 #main #editor .CodeMirror { flex-grow: 1; }
 #main #editor .CodeMirror-gutters { padding-right: 10px; }
-#editor { flex-grow: 1; display: flex; flex-direction: column; }
+#editor { flex-grow: 1; display: flex; flex-direction: column; width: 100px; }
 #editor .breakpoints { width: 10px; }
 #editor .breakpoint  { color: #f92672; margin-left: 5px; }
 


### PR DESCRIPTION
If a flex child doesn't specify a minimum width, it defaults to the size of its contents. This causes a problem when the editor contains long lines of text, so the div goes outside the browser window.

This gives the editor a minimum width so it fills the remaining browser space correctly.

Btw any reason the CSS is in the HTML file instead of the styles?