### PR TITLE
Fix compatibility profiles not highlighting anymore

### DIFF
--- a/js/tool-options.js
+++ b/js/tool-options.js
@@ -40,7 +40,7 @@ function updateOptions() {
   compatProfile.setValue('none')
   for (key in compatibilityProfiles) {
     const p = compatibilityProfiles[key]
-    const same = Object.keys(p).every(x => emulator[x] == !!p[x])
+    const same = Object.keys(p).every(x => emulator[x] == p[x])
     if (same) compatProfile.setValue(key)
   }
 


### PR DESCRIPTION
Broke this with #87. Weak comparison is good enough for a bunch of visual settings anyways.