### PR TITLE
Fix screen clearing on lores/hires transition.

### DIFF
--- a/js/shared.js
+++ b/js/shared.js
@@ -105,15 +105,14 @@ function renderDisplay(emulator) {
 	var c = document.getElementById(renderTarget);
 
 	// Canvas rendering can be expensive. Exit out early if nothing has changed.
-	// NOTE: toggling emulator.hires changes emulator.p dimensions.
-	var colors = [emulator.backColor, emulator.fillColor, emulator.fillColor2, emulator.blendColor];
+	var colors = [emulator.backgroundColor, emulator.fillColor, emulator.fillColor2, emulator.blendColor];
 	if (c.last !== undefined) {
 		if (arrayEqual(c.last.p[0], emulator.p[0]) && arrayEqual(c.last.p[1], emulator.p[1])
 				&& arrayEqual(c.last.colors, colors)) {
 			return;
 		}
-		if (c.last.p[0].length != emulator.p[0].length)
-			c.last = undefined
+		if (c.last.hires !== emulator.hires)
+			c.last = undefined;  // full redraw when switching resolution
 	}
 	var g = c.getContext("2d");
 	getTransform(emulator, g);
@@ -138,7 +137,8 @@ function renderDisplay(emulator) {
 
 	c.last = {
 		colors: colors,
-		p: [emulator.p[0].slice(), emulator.p[1].slice()]
+		p: [emulator.p[0].slice(), emulator.p[1].slice()],
+		hires: emulator.hires,
 	};
 }
 


### PR DESCRIPTION
This was broken in ad757955c78e, and presented in Mr Worm, where the
lo-res title screen wasn't cleared when starting hi-res gameplay:
http://johnearnest.github.io/Octo/index.html?gist=f3685a75817cde6d5c0d