### PR TITLE
Remove outdated Google Group

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,6 @@ General information:
 - [Metaprogramming Cookbook](https://github.com/JohnEarnest/Octo/blob/gh-pages/docs/MetaProgramming.md)
 - [SuperChip Extensions](https://github.com/JohnEarnest/Octo/blob/gh-pages/docs/SuperChip.md)
 - [XO-Chip Extensions](https://github.com/JohnEarnest/Octo/tree/gh-pages/docs/XO-ChipSpecification.md)
-- [Octo Programming Google Group](https://groups.google.com/forum/#!forum/octo-programming)
 - [OctoJam](http://octojam.com) an Octo-centric game jam held every October.
 - [Chip-8 Archive](https://github.com/JohnEarnest/chip8Archive) A curated gallery of Chip-8 Programs.
 


### PR DESCRIPTION
The Google Group doesn't seem to exist anymore? I can't access it, at least.