### PR TITLE
added server for easy local development and a karma testing configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 tools/Doct/doct.o
 tools/Doct/doct
 tools/Doct/rom.h
+
+node_modules/
+dist/
+.cache/
+package-lock.json
+.vscode

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,19 @@
+module.exports = function(config) {
+  config.set({
+    browsers: ['ChromeHeadless'],
+    frameworks: ['jasmine'],
+    basePath: '',
+    files: [
+      'lib/codemirror/codemirror.min.js',
+      'lib/codemirror/octomode.js',
+      'lib/filesaver.js',
+      'js/emulator.js',
+      'js/compiler.js',
+      'js/decompiler.js',
+      'js/shared.js',
+      'js/util.js',
+      'js/input.js',
+      'spec/*.js'
+    ],
+  })
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "octo",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "http-server",
+    "test": "karma start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "",
+  "devDependencies": {
+    "http-server": "^0.12.1",
+    "jasmine-core": "^3.5.0",
+    "karma-chrome-launcher": "^3.1.0",
+    "karma-jasmine": "^3.1.1",
+    "karma": "^4.4.1"
+  }
+}

--- a/spec/shared.spec.js
+++ b/spec/shared.spec.js
@@ -1,0 +1,16 @@
+describe('packOptions', () => {
+  it('returns options object with all optionsFlags properties from argument', () => {
+    const expectedObject = optionFlags.reduce((obj, flag) => {
+      obj[flag] = 'test';
+      return obj}, {})
+
+    const objectWithOptionsAndOther = Object.assign({
+      should: 'nope',
+      not: 'nope',
+      show: 'nope',
+      up: 'nope',
+    }, expectedObject);
+
+    expect(packOptions(objectWithOptionsAndOther)).toEqual(expectedObject);
+  })
+});


### PR DESCRIPTION
Just trying to make development easier to get started with. Simple npm setup for server and testing. I can add some sort of getting started developing doc with instructions too, if you want.

npm start and octo will be at localhost:8080
npm test will run the tests in the spec directory

Dunno if it's of interest to you or not, but here it is. If I can change anything to make it more useful to you, let me know.