### PR TITLE
Locate resources relative to source file, not cwd

### DIFF
--- a/octo
+++ b/octo
@@ -6,6 +6,7 @@ const compiler   = require('./js/compiler')
 const decompiler = require('./js/decompiler')
 const sharing    = require('./js/sharing')
 const fs         = require('fs')
+const path       = require('path')
 
 /**
 *
@@ -87,11 +88,11 @@ function compileFile(src, dst, options) {
 			rom:     programRom,
 		})}</script>\n`;
 		([
-			{u:'js/emulator.js', f:x=>`<script>${x}</script>\n`},
-			{u:'js/shared.js',   f:x=>`<script>${x}</script>\n`},
-			{u:'js/input.js',    f:x=>`<script>${x}</script>\n`},
+			{u:'./js/emulator.js', f:x=>`<script>${x}</script>\n`},
+			{u:'./js/shared.js',   f:x=>`<script>${x}</script>\n`},
+			{u:'./js/input.js',    f:x=>`<script>${x}</script>\n`},
 			{u:'standalone.html',f:x=>x},
-		]).forEach(x => page += x.f(fs.readFileSync(x.u, { encoding:'utf8' })))
+		]).forEach(x => page += x.f(fs.readFileSync(path.resolve(__dirname, x.u), { encoding:'utf8' })))
 		fs.writeFileSync(dst, page)
 	}
 	else if (dst) fs.writeFileSync(dst, programBinary, { encoding:'binary' })


### PR DESCRIPTION
The code was looking for javascript relative to the current working directory. Calling octo outside the project root with an html output failed to find the javascript and standalone.html.