### PR TITLE
Update hyperlinks to VIPER issues

### DIFF
--- a/docs/XO-ChipSpecification.md
+++ b/docs/XO-ChipSpecification.md
@@ -4,7 +4,7 @@ title: Octo Extensions
 
 Octo Extensions
 ===============
-In the process of developing Octo, I have written and studied many Chip8 and SuperChip8 programs. I have also researched historical attempts to extend Chip8 such as [CHIP-8E](http://www.mattmik.com/files/viper/Volume2Issue08_09.pdf) as well as more modern and less conservative approaches like [Chip16](https://github.com/chip16/chip16). Chip8 has a simple, elegant instruction set which is easy to learn, but using it extensively reveals some shortcomings which limit the kinds of programs which can be written (to say nothing of convenience). In this document I will describe a series of extended instructions Octo provides called "XO-Chip" which, like SuperChip8, retain backwards compatibility with the original Chip8 instructions. The additions are sparing and try to retain some degree of historical plausibility and the flavor of Chip8's creative limitations. Authors of future Chip8 interpreters are encouraged to provide support for these instructions.
+In the process of developing Octo, I have written and studied many Chip8 and SuperChip8 programs. I have also researched historical attempts to extend Chip8 such as [CHIP-8E](https://github.com/mattmikolay/viper/blob/master/volume2/issue8_9.pdf) as well as more modern and less conservative approaches like [Chip16](https://github.com/chip16/chip16). Chip8 has a simple, elegant instruction set which is easy to learn, but using it extensively reveals some shortcomings which limit the kinds of programs which can be written (to say nothing of convenience). In this document I will describe a series of extended instructions Octo provides called "XO-Chip" which, like SuperChip8, retain backwards compatibility with the original Chip8 instructions. The additions are sparing and try to retain some degree of historical plausibility and the flavor of Chip8's creative limitations. Authors of future Chip8 interpreters are encouraged to provide support for these instructions.
 
 The XO-Chip instructions are summarized as follows:
 
@@ -28,7 +28,7 @@ Chip8 memory operations can prove clumsy. `load` and `save` place low registers 
 	i := buffer2
 	load v3
 
-Chip8E proposes a pair of instructions which load and save register ranges, specifying both a minimum and maximum (inclusive) register. XO-Chip adopts these as described by the Chip-8E instruction encoding ([VIPER Vol 2, Issue 8 & 9, Page 16](http://www.mattmik.com/files/viper/Volume2Issue08_09.pdf)) . Their Octo forms are written with a dash between the two registers to denote a range. Using these instructions, the above code could instead be written as:
+Chip8E proposes a pair of instructions which load and save register ranges, specifying both a minimum and maximum (inclusive) register. XO-Chip adopts these as described by the Chip-8E instruction encoding ([VIPER Vol 2, Issue 8 & 9, Page 16](https://github.com/mattmikolay/viper/blob/master/volume2/issue8_9.pdf)) . Their Octo forms are written with a dash between the two registers to denote a range. Using these instructions, the above code could instead be written as:
 
 	i := buffer1
 	load v4 - v7

--- a/examples/tank.8o
+++ b/examples/tank.8o
@@ -4,7 +4,7 @@
 #
 #  Classic Chip8 program translated from
 #  VIPer Volume 1 Issue 1 (June 1978), pg 12-14
-#  http://mattmik.com/downloads/viper/Volume1Issue01.pdf
+#  https://github.com/mattmikolay/viper/blob/master/volume1/issue1.pdf
 #
 #  Press 2/E/S/Q to move the tank.
 #


### PR DESCRIPTION
I've moved the VIPER issues to GitHub. At some point in the future, I may remove them from my personal site.

This PR updates all URLs linking to the VIPER issues hosted on my personal website to reference GitHub instead.