### PR TITLE
Finer-grained time for pulse generation

### DIFF
--- a/js/shared.js
+++ b/js/shared.js
@@ -273,12 +273,16 @@ function playPattern(soundLength,buffer,pitch=PITCH_BIAS,
 	var step = freq / audio.sampleRate;
 	var pos = sampleState.pos;
 
-	var lowPassAlpha = getLowPassAlpha(audio.sampleRate);
+	var quality = 8;
+	var lowPassAlpha = getLowPassAlpha(audio.sampleRate * quality);
 	
 	for(var i = 0, il = samples; i < il; i++) {
-		var cell = pos >> 3, shift = pos & 7 ^ 7;
-		audioBuffer[i] = getLowPassFilteredValue(lowPassAlpha, buffer[cell] >> shift & 1);
-		pos = ( pos + step ) % bufflen;
+		for (var j = 0; j < quality; ++j) {
+			var cell = pos >> 3, shift = pos & 7 ^ 7;
+			var value = getLowPassFilteredValue(lowPassAlpha, buffer[cell] >> shift & 1);
+			pos = ( pos + step/quality ) % bufflen;
+		}
+		audioBuffer[i] = value;
 	}
 
 	audioData.push(new AudioBuffer(audioBuffer, samples));


### PR DESCRIPTION
It's a potential fix for the problem described in https://github.com/JohnEarnest/Octo/pull/147

My earlier PR had focused on filtering out aliasing frequencies, which I think is important. However, I hadn't realized that @Kouzeru 's code was fixing a different artifact that comes from accessing the sample only at discrete time intervals. If we're unlucky with frequency ratios and rounding, the audio we emit (before low-pass filtering) can oscillate between patterns like these:

```
xxx....xxx....
xxxx...xxxx...
```

Octo has always had this artifact, but I think that alone isn't a great reason to keep it. It's an annoying droning noise for some frequencies and bit patterns as the resonance shifts, maybe a few times per second. @Kouzeru 's fix was to sample at a higher rate, which this PR reinstantiates. (And to my understanding, also what some 8-bit era sound chips did to avoid this kind of artifact.)