### PR TITLE
Audio and Sprite Editor Interface Revamp

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,10 +66,7 @@
         <div class='buttonbar'>
           <div id='sprite-16'>16x16 Sprite</div>
           <div id='sprite-color'>Color Sprite</div>
-          <div id='sprite-left'>&lt;&lt;1</div>
-          <div id='sprite-right'>&gt;&gt;1</div>
-          <div id='sprite-up'>&and;</div>
-          <div id='sprite-down'>&or;</div>
+          <div id='sprite-invert'>Invert</div>
           <div id='sprite-clear'>Clear</div>
         </div>
         <div id='sprite-palette'>
@@ -81,28 +78,59 @@
         <div class='preview-container'>
           <canvas id='sprite-draw'></canvas>
         </div>
+        <div class='buttonbar' style='font-family:Cambria, serif'>
+          <div id='sprite-up'   >&uarr;</div>
+          <div id='sprite-down' >&darr;</div>
+          <div id='sprite-left' >&larr;</div>
+          <div id='sprite-right'>&rarr;</div> 
+          <div id='sprite-vflip'>&vArr;</div>
+          <div id='sprite-hflip'>&hArr;</div>
+          <div id='sprite-rotCC' style='display:none'>&#x21BA;</div>
+          <div id='sprite-rotCW' style='display:none'>&#x21BB;</div>
+        </div>
         <div id='sprite-editor'></div>
+        <div>Blend Sprite With</div>
+        <div id='sprite-blend'></div>
+        <div class='buttonbar'>
+          <div id='sprite-swap'>Swap</div>
+          <div id='sprite-or'  >OR</div>
+          <div id='sprite-and' >AND</div>
+          <div id='sprite-xor' >XOR</div>
+        </div>
       </div>
 
       <div data-panel='audio' class='tool-header'>Audio Editor</div>
       <div data-panel='audio' class='tool-body'>
         <h1>Audio Pattern</h1>
-        <div id='audio-error'></div>
-        <div class='preview-container'>
-          <canvas id='audio-pattern-view' width='256' height='32'></canvas>
+        <div id='audio-preview-group'>
+          <span class='preview-container'>
+            <canvas id='audio-pattern-view' width='256' height='32'></canvas>
+          </span>
+          <span id='audio-play'   class='button'>Play</span>
         </div>
         <div id='audio-pattern-editor'></div>
         <div id='audio-tone-group'>
-          <div class='pair'>Pitch: <input id='audio-pitch' value='64'></div>
-          <div id='audio-left'   class='button'>&lt;&lt;</div>
-          <div id='audio-right'  class='button'>&gt;&gt;</div>
-          <div id='audio-random' class='button'>Randomize</div>
-          <div id='audio-play'   class='button'>Play</div>
+          <div id='audio-left'    class='button'>&lt;&lt;</div>
+          <div id='audio-right'   class='button'>&gt;&gt;</div>
+          <div id='audio-reverse' class='button'>Reverse</div>
+          <div id='audio-invert'  class='button'>Invert</div>
+          <div id='audio-random'  class='button'>Noise</div>
+          <div id='audio-clear'   class='button'>Clear</div>
         </div>
-
+        <h1>Pitch Selector</h1>
+        <div id='audio-preview-group'>
+          <span class='preview-container'>
+            <canvas id='audio-piano-keys' width='280' height='32'></canvas>
+          </span>
+          <span class='pair'>Pitch: <input id='audio-pitch' value='64'></span>
+        </div>
+        <center><i><div id='audio-error'>Left / right click to play tone / audio pattern</div></i></center>
         <h1>Tone Generator</h1>
-        <div class='preview-container'>
-          <canvas id='audio-tone-view' width='256' height='32'></canvas>
+        <div id='audio-preview-group'>
+          <span class='preview-container'>
+            <canvas id='audio-tone-view' width='256' height='32'></canvas>
+          </span>
+          <span id='audio-tone-preview' class='button'>Play</span>
         </div>
         <div>Blend Mode</div>
         <div id='audio-blend-mode'>
@@ -112,14 +140,11 @@
           <span data-value='xor' >XOR </span>
         </div>
         <div id='audio-tone-group'>
-          <div class='pair'>Width: <input id='audio-width' value='16'></div>
-          <div class='pair'>Pulse: <input id='audio-pulse' value='0.5'></div>
-          <div class='pair'>Frequency: <input id='audio-freq' value='440'> Hz</div>
+          <div class='pair'>Duty: <input id='tone-duty' value='50'> %</div>
+          <div class='pair'>Pulse: <input id='tone-pulse' value='4'></div>
+          <div id='audio-generate' class='button'>Generate</div>
         </div>
-        <div id='audio-tone-group'>
-          <div id='audio-tone-preview' class='button'>Play</div>
-          <div id='audio-generate'     class='button'>Generate</div>
-        </div>
+        <center><i><div id='tone-info'></div></i></center>
       </div>
 
       <div data-panel='binary' class='tool-header'>Binary Tools</div>
@@ -442,7 +467,7 @@
 .radiobar>span:active, .radiobar .selected { background: #444; color: white; }
 
 /* reusable horizontal bar of buttons */
-.buttonbar { display: flex; flex-direction: row; margin-top: 10px; }
+.buttonbar { display: flex; flex-direction: row; margin: 6px; }
 .buttonbar>div, .button {
   flex-grow: 1;
   text-align: center;
@@ -559,15 +584,18 @@ input:focus { outline: none; }
 #toolbox h1 { font-size: 13px; padding-top:10px; padding-bottom:5px; margin:0; }
 #toolbox canvas { border:1px solid black; }
 #toolbox .CodeMirror { margin-top: 10px; border: 1px solid black; }
-.preview-container { display:flex; flex-direction:row; justify-content:center; margin-top:10px; }
+.preview-container { display:flex; flex-direction:row; justify-content:center; margin:5px; }
 
-#sprite-palette { margin-top: 10px; display: none; }
-#sprite-editor .CodeMirror { height: 115px; }
+#sprite-palette { margin-top: 10px; display: none; text-shadow: 1px 1px #808080; color: black; }
+#sprite-editor .CodeMirror { height:40px; margin:6px }
+#sprite-blend .CodeMirror { height:40px; margin:2px 6px; }
 #audio-pattern-editor .CodeMirror { height: 40px; }
-#audio-tone-group { display: flex; flex-direction: row; margin-top: 10px; align-items: center; }
+#audio-tone-group, #audio-preview-group { display: flex; flex-direction: row; align-items: center; }
+#audio-preview-group { margin-bottom: 8px; }
+#audio-tone-group { margin: 10px; }
 #audio-tone-group .pair { margin-right: 15px; }
 #audio-tone-group .button { margin-left: 10px; }
-#audio-tone-group input { width:60px; height:30px; margin-left:5px; }
+#audio-tone-group input, #audio-preview-group input { width:60px; height:30px; margin-left:5px; }
 #binary-editor        .CodeMirror { height: 100px; }
 #binary-filename { width: 100%; }
 
@@ -990,10 +1018,9 @@ function runRom(rom) {
   setRenderTarget(5, 'target')
 
   var frameTime = 1000/60;
-  var last = Date.now(), diff, origin = last+frameTime/2;
+  var timeCount = Date.now() + frameTime / 2;
   var stepFrame = _ => {
-    diff = (Date.now() - last); last += diff;
-    for(var k = 0; origin < last - frameTime && k < 2; origin += frameTime, k++){
+    for(var k = 0; timeCount < Date.now() && k < 2; timeCount += frameTime, k++){
       for(var z = 0; (z < emulator.tickrate) && (!emulator.waiting); z++) {
         if (!emulator.breakpoint) {
           if (emulator.vBlankQuirks && ((emulator.m[emulator.pc] & 0xF0) == 0xD0)) { z = emulator.tickrate }

--- a/js/shared.js
+++ b/js/shared.js
@@ -206,7 +206,10 @@ function audioSetup(emulator) {
 	}
 	audioEnable()
 	if (audio && !audioNode) {
-		audioNode = audio.createScriptProcessor(2048, 1, 1);
+		var bufferSize = // set bufferSize according to environment's samplerate
+			audio.sampleRate <  64000 ? 2048 : // for 48000hz or 44100hz or less
+			audio.sampleRate < 128000 ? 4096 : 8192; // for 96000hz or more
+		audioNode = audio.createScriptProcessor(bufferSize, 1, 1);
 		audioNode.gain = audio.createGain();
 		audioNode.gain.gain.value = VOLUME ;
 		audioNode.onaudioprocess = function(audioProcessingEvent) {
@@ -273,7 +276,7 @@ function playPattern(soundLength,buffer,pitch=PITCH_BIAS,
 	var step = freq / audio.sampleRate;
 	var pos = sampleState.pos;
 
-	var quality = 8;
+	var quality = Math.ceil( 192000 / audio.sampleRate ) * 2;
 	var lowPassAlpha = getLowPassAlpha(audio.sampleRate * quality);
 	
 	for(var i = 0, il = samples; i < il; i++) {

--- a/js/tool-audio.js
+++ b/js/tool-audio.js
@@ -2,6 +2,7 @@
 * Audio editor:
 **/
 
+const audioPianoKeys = document.getElementById('audio-piano-keys')
 const audioPatternEditor = textBox(document.getElementById('audio-pattern-editor'), false, '')
 const audioPatternCanvas = document.getElementById('audio-pattern-view')
 const audioToneCanvas = document.getElementById('audio-tone-view')
@@ -9,10 +10,12 @@ const audioBlendMode = radioBar(document.getElementById('audio-blend-mode'), 'no
 
 const PATTERN_SIZE = 16
 const PATTERN_SCALE = 2
-const emptySound = range(PATTERN_SIZE).map(_ => 0)
+
 function readPattern(source)         { return readBytes(source, PATTERN_SIZE) }
 function writePattern(target, bytes) { return writeBytes(target, PATTERN_SIZE, bytes) }
-writePattern(audioPatternEditor, emptySound)
+
+var audioPatternData = range(PATTERN_SIZE).map(_ => 0)
+writePattern(audioPatternEditor, audioPatternData)
 
 function drawBytes(target, bytes) {
 	const w = target.width
@@ -34,6 +37,16 @@ function shiftBytes(bytes, n) {
 	}
 	return r
 }
+function flipBytes(bytes, n){
+	return bytes.map(x => x ^ 0xFF)
+}
+
+function reverseBits(bytes, n){
+	return bytes.reverse().map(x =>
+		x>>7& 1|x>>5& 2|x>>3& 4|x>>1&  8|
+		x<<1&16|x<<3&32|x<<5&64|x<<7&128)
+}
+
 function playBytes(pattern, pitch){
 	if (audioSetup(emulator)) {
 		playPattern(0.5,pattern,pitch)
@@ -44,6 +57,52 @@ function playBytes(pattern, pitch){
 }
 
 /**
+*  Piano keys panel
+**/
+
+function drawPiano(pressed=-1){
+	const g = audioPianoKeys.getContext('2d');
+	const octaves = 5, keywidth = 8;
+	
+	g.fillStyle = emulator.backgroundColor;
+	g.fillRect(0,0,7*keywidth*octaves,32);
+
+	// render white keys
+	for (let key=0,keypos=0;key<octaves*7;key++,keypos+=keywidth){
+		g.fillStyle = Math.ceil(12*(Math.floor(key)-3)/7)+5 == pressed ?
+			emulator.blendColor : emulator.fillColor;
+		g.fillRect(keypos,0,keywidth-1,31);
+	}
+	// render black keys
+	for ( var m = 0; m < 2; m++ ){
+		for (let key=0,keypos=-1;key<octaves*5;key++,keypos += keywidth + 1){
+			if ( key%5 == 2 ) keypos += 6; if ( key%5 == 0 )  keypos += 5;
+			g.fillStyle = !m ? emulator.backgroundColor :
+				(Math.ceil(12*(key+1)/5)-2 != pressed)?
+				emulator.fillColor2:emulator.blendColor;
+			g.fillRect(keypos-m,-m,keywidth-2,20);
+		}
+	}
+}
+
+drawOnCanvas(audioPianoKeys, (x, y, draw) => {
+	const keywidth = 8;
+	// try to hover the piano keys
+	var k = x / keywidth + 0.5;
+	var press = !( y<20 && (k)%1<0.75 && 
+		( Math.floor(k)%7!=2 || Math.floor(k)%7!=6 ) )?
+		Math.ceil( 12 * ( Math.floor(k - 0.5 ) - 3 ) / 7 ) + 5:
+		Math.ceil( 12 * ( Math.floor(k) - 3 ) / 7 ) + 4;
+	audioPitch.value = press * 4 + 19;
+	updatePiano();
+}, (x, y, draw) => {
+	switch(draw){
+		case 1: tonePreview(); break;
+		case 2: audioPreview(); break;
+	}
+})
+
+/**
 * Pattern panel
 **/
 
@@ -51,37 +110,50 @@ const audioPitch = document.getElementById('audio-pitch')
 
 drawOnCanvas(audioPatternCanvas, (x, y, draw) => {
 	const index   = Math.min(PATTERN_SIZE*8, Math.max(0, Math.floor(x / PATTERN_SCALE)))
-	const pattern = readPattern(audioPatternEditor)
-	setBit(pattern, index, draw)
-	writePattern(audioPatternEditor, pattern)
+	setBit(audioPatternData, index, draw == 1)
+	drawBytes(audioPatternCanvas, audioPatternData)
+},(x, y, draw) => {
+	writePattern(audioPatternEditor, audioPatternData)
 	updateAudio()
 })
-function audioPreview(){
-	playBytes(readPattern(audioPatternEditor), Math.max(0,Math.min(+audioPitch.value,255)))
+
+document.getElementById('audio-reverse').onclick = _ => {
+	writePattern(audioPatternEditor, audioPatternData = reverseBits(audioPatternData))
+	updateAudio()
+}
+document.getElementById('audio-invert').onclick = _ => {
+	writePattern(audioPatternEditor, audioPatternData = flipBytes(audioPatternData))
+	updateAudio()
 }
 document.getElementById('audio-left').onclick = _ => {
-	writePattern(audioPatternEditor, shiftBytes(readPattern(audioPatternEditor), 1))
+	writePattern(audioPatternEditor, audioPatternData = shiftBytes(audioPatternData, 1))
 	updateAudio()
 }
 document.getElementById('audio-right').onclick = _ => {
-	writePattern(audioPatternEditor, shiftBytes(readPattern(audioPatternEditor), -1))
+	writePattern(audioPatternEditor, audioPatternData = shiftBytes(audioPatternData, -1))
 	updateAudio()
 }
-document.getElementById('audio-play').onclick = _ => audioPreview()
+
 document.getElementById('audio-random').onclick = _ => {
-	audioPitch.value=(Math.random() * 256) & 0xFF
-	writePattern(audioPatternEditor, emptySound.map(_ => (Math.random() * 256) & 0xFF))
-	updateAudio()
-	audioPreview()
+	writePattern(audioPatternEditor,
+	audioPatternData = audioPatternData.map(_ => (Math.random() * 256) & 0xFF))
+	updateAudio(); audioPreview()
 }
+
+document.getElementById('audio-clear').onclick = _ => {
+	writePattern(audioPatternEditor, audioPatternData = audioPatternData.map(_=>0));
+	updateAudio(); 
+}
+
+document.getElementById('audio-play').onclick = audioPreview
 
 /**
 * Tone Generator panel
 **/
 
-const toneDuty  = document.getElementById('audio-width')
-const tonePulse = document.getElementById('audio-pulse')
-const toneFreq  = document.getElementById('audio-freq')
+const tonePulse  = document.getElementById('tone-pulse')
+const toneDuty   = document.getElementById('tone-duty')
+const toneInfo   = document.getElementById('tone-info')
 
 function audioBlend(){
 	return ({
@@ -91,43 +163,60 @@ function audioBlend(){
 		xor : (x,y)=>x^y,
 	})[audioBlendMode.getValue()]
 }
+
 function audioTone(){
-	const duty=Math.max(0,Math.min(+toneDuty.value,255))
-	const freq=+toneFreq.value
-	const pulse=Math.ceil(tonePulse.value*duty)
+	const pulse=128/Math.max(0,Math.min(+tonePulse.value,64))
+	const duty=Math.ceil(toneDuty.value*pulse/100)
 	const blend=audioBlend()
-	const pattern=readPattern(audioPatternEditor).map((old,i) => {
+	return audioPatternData.map((old,i) => {
 		let r=0
-		for(let b=0;b<8;b++) r |= ((i*8+b)%duty<pulse?1:0)*(1<<(7-b))
+		for(let b=0;b<8;b++) r |= ((i*8+b)%pulse<duty?1:0)*(1<<(7-b))
 		return blend(old,r)
 	})
-	const pitch=0|Math.max(0,Math.min(255, Math.log2((freq*duty)/4000)*48+64))
-	return {pattern,pitch}
 }
-toneDuty.onchange =toneDuty.onkeyup =updateAudio
-tonePulse.onchange=tonePulse.onkeyup=updateAudio
-toneFreq.onchange =toneFreq.onkeyup =updateAudio
 
-document.getElementById('audio-tone-preview').onclick = _ => {
-	const tone=audioTone()
-	playBytes(tone.pattern,tone.pitch)
-}
+toneDuty.onchange = toneDuty.onkeyup = updateAudio
+tonePulse.onchange = tonePulse.onkeyup = updateAudio
+audioPitch.onchange = audioPitch.onkeyup = updatePiano
+
+document.getElementById('audio-tone-preview').onclick = tonePreview
+
 document.getElementById('audio-generate').onclick = _ => {
-	const tone=audioTone()
-	writePattern(audioPatternEditor, tone.pattern)
-	audioPitch.value=tone.pitch
-	updateAudio()
-	audioPreview()
+	writePattern(audioPatternEditor, audioPatternData = audioTone())
+	updateAudio(); audioPreview()
 }
 
 /**
 * Main
 **/
 
+function audioPreview(){ playBytes(audioPatternData, +audioPitch.value) }
+function tonePreview(){ playBytes(audioTone(), +audioPitch.value) }
+
 function updateAudio() {
 	audioPatternEditor.refresh()
-	drawBytes(audioPatternCanvas, readPattern(audioPatternEditor))
-	const tone=audioTone()
-	drawBytes(audioToneCanvas, tone.pattern)
+	drawBytes(audioPatternCanvas, audioPatternData)
+	drawBytes(audioToneCanvas, audioTone())
+	updatePiano()
 }
-audioPatternEditor.on('change', updateAudio)
+
+function updatePiano() {
+	drawPiano(Math.floor((+audioPitch.value-19)/4));
+	updateNoteInfo(+audioPitch.value,Math.max(0,Math.min(+tonePulse.value,64)));
+}
+
+function updateNoteInfo(pitch,multiply) {
+	let freq = multiply*4000*2**((pitch-64)/48)/128;
+	let note = Math.round(Math.log2(freq/440)*48);
+	let dist = note-Math.round(Math.log2(freq/440/multiply)*48);
+	let intv = (dist<0?"":"+")+Math.round(dist/4)+" ("+dist+")";
+	let nfrq = 2**(Math.round(note/4)/12)*440;
+	let ikey = (12+Math.round(note/4)%12)%12;
+	let nkey = "AABCCDDEFFGG"[ikey]+"-$--$-$--$-$"[ikey]+
+		Math.floor((Math.round(note/4)-3)/12+5);
+	toneInfo.innerHTML = freq.toFixed(2)+" hz ≈ "+
+		nfrq.toFixed(2)+" hz ["+nkey+"]; "+intv;
+}
+
+audioPatternEditor.on('change', _=>(
+	audioPatternData=readPattern(audioPatternEditor),updateAudio()))

--- a/js/tool-sprite.js
+++ b/js/tool-sprite.js
@@ -2,15 +2,14 @@
 * Sprite editor:
 **/
 
-const SPRITE_SCALE  = 20
+const SPRITE_SCALE  = 16
 const spriteDraw    = document.getElementById('sprite-draw')
 const sprite16      = toggleButton(document.getElementById('sprite-16'), 0, changeSpriteSize)
 const spriteColor   = toggleButton(document.getElementById('sprite-color'), 0, updateSpriteEditor)
-const spriteClear   = document.getElementById('sprite-clear')
 const spritePalette = radioBar(document.getElementById('sprite-palette'), 1, x => {})
 const spriteEditor  = textBox(document.getElementById('sprite-editor'), false, '')
+const spriteBlend   = textBox(document.getElementById('sprite-blend'), false, '')
 
-spriteClear.onclick = _ => { spritePixels = []; updateSpriteEditor() }
 function spriteLength() { return (sprite16.getValue() ? 32 : 15) * (spriteColor.getValue() ? 2 : 1) }
 function spriteDim(big) { return big ? { rows:16, cols:16 } : { rows:15, cols:8 } }
 
@@ -66,6 +65,11 @@ function setSpritePixels(dim, pix) {
   })
 }
 function changeSpriteSize(toBig) {
+  let temp = spritePixels;
+  spritePixels = readBytes(spriteBlend, 64)
+  setSpritePixels(spriteDim(toBig), getSpritePixels(spriteDim(!toBig), 0, 0))
+  showHex(spriteBlend,spritePixels);
+  spritePixels = temp;
   setSpritePixels(spriteDim(toBig), getSpritePixels(spriteDim(!toBig), 0, 0))
   updateSpriteEditor()
 }
@@ -74,7 +78,51 @@ function scrollSprite(dx, dy) {
   setSpritePixels(dim, getSpritePixels(dim, dx, dy))
   updateSpriteEditor()
 }
+function spriteFlipH(){ // Flip Horizontally
+  const c = spriteColor.getValue()
+  const dim = spriteDim(sprite16.getValue())
+  setSpritePixels(dim, range(dim.rows).map(row => {
+    return range(dim.cols).map(col => {
+      return getSpritePixel(dim.cols-col-1, row,dim.cols == 16, c)
+    })
+  }));
+}
+function spriteFlipV(){ // Flip Vertically
+  const c = spriteColor.getValue()
+  const dim = spriteDim(sprite16.getValue())
+  setSpritePixels(dim, range(dim.rows).map(row => {
+    return range(dim.cols).map(col => {
+      return getSpritePixel(col,dim.rows-row-1,dim.cols == 16, c)
+    })
+  }));
+}
+function spriteFlipD(){ // Flip Diagonally
+  const c = spriteColor.getValue()
+  const dim = spriteDim(sprite16.getValue())
+  setSpritePixels(dim, range(dim.rows).map(row => {
+    return range(dim.cols).map(col => {
+      return getSpritePixel(row,col,dim.cols == 16, c)
+    })
+  }));
+}
 
+/**
+*  Blending:
+**/
+
+function spriteBlendSwap(){
+  let temp = readBytes(spriteBlend, spriteLength());
+  showHex(spriteBlend,spritePixels);
+  showHex(spriteEditor,temp);
+  spritePixels = temp; updateSpriteEditor();
+}
+
+function spriteBlendFunc(func){
+  let temp = readBytes(spriteBlend, spriteLength());
+  for(var i=0;i<temp.length;i++)
+    spritePixels[i] = func(spritePixels[i],temp[i]);
+  showHex(spriteEditor,spritePixels); updateSpriteEditor();
+}
 /**
 * Data binding:
 **/
@@ -84,9 +132,9 @@ function scrollSprite(dx, dy) {
 // and does not ignore writes that are identical to the current data.
 var spriteHandlingRefresh = false
 
-function showHex() {
+function showHex(target, data) {
   if (spriteHandlingRefresh) return
-  writeBytes(spriteEditor, spriteLength(), spritePixels)
+  writeBytes(target, spriteLength(), data)
 }
 
 spriteEditor.on('change', _ => {
@@ -118,11 +166,26 @@ function showSprite() {
 /**
 * Main:
 **/
+document.getElementById('sprite-clear' ).onclick = _ => {
+  spritePixels = []; updateSpriteEditor() }
+document.getElementById('sprite-invert').onclick = _ => {
+  spritePixels = spritePixels.map(_=>_^255); updateSpriteEditor()  }
 
 document.getElementById('sprite-left' ).onclick = _ => scrollSprite(-1, 0)
 document.getElementById('sprite-right').onclick = _ => scrollSprite( 1, 0)
 document.getElementById('sprite-up'   ).onclick = _ => scrollSprite( 0,-1)
 document.getElementById('sprite-down' ).onclick = _ => scrollSprite( 0, 1)
+document.getElementById('sprite-swap' ).onclick = _ => spriteBlendSwap()
+document.getElementById('sprite-or'   ).onclick = _ => spriteBlendFunc((a,b)=>(a|b))
+document.getElementById('sprite-and'  ).onclick = _ => spriteBlendFunc((a,b)=>(a&b))
+document.getElementById('sprite-xor'  ).onclick = _ => spriteBlendFunc((a,b)=>(a^b))
+document.getElementById('sprite-hflip').onclick = _ => (spriteFlipH(),updateSpriteEditor())
+document.getElementById('sprite-vflip').onclick = _ => (spriteFlipV(),updateSpriteEditor())
+document.getElementById('sprite-rotCC').onclick = _ => (spriteFlipH(),spriteFlipD(),updateSpriteEditor())
+document.getElementById('sprite-rotCW').onclick = _ => (spriteFlipV(),spriteFlipD(),updateSpriteEditor())
+
+const spriteRotCW = document.getElementById('sprite-rotCW')
+const spriteRotCC = document.getElementById('sprite-rotCC')
 
 drawOnCanvas(spriteDraw, (x, y, draw) => {
   setSpritePixel(
@@ -130,8 +193,10 @@ drawOnCanvas(spriteDraw, (x, y, draw) => {
     Math.floor(y / SPRITE_SCALE),
     sprite16.getValue(),
     spriteColor.getValue(),
-    draw ? spritePalette.getValue() : 0
+    draw == 1 ? spritePalette.getValue() : 0
   )
+  showSprite()
+}, (x, y, draw) => {
   updateSpriteEditor()
 })
 
@@ -139,21 +204,36 @@ function updateSpriteEditor() {
   document.querySelectorAll('#sprite-palette>span').forEach((x,i) => {
     x.style.backgroundColor = getColor(i)
   })
+  
   if (sprite16.getValue()) {
     spriteDraw.width  = SPRITE_SCALE * 16
     spriteDraw.height = SPRITE_SCALE * 16
+    spriteRotCC.style.display = "block"
+    spriteRotCW.style.display = "block"
   }
   else {
     spriteDraw.width  = SPRITE_SCALE * 8
     spriteDraw.height = SPRITE_SCALE * 15
+    spriteRotCC.style.display = "none"
+    spriteRotCW.style.display = "none"
   }
   if (!spriteColor.getValue()) {
     spritePalette.setValue(1)
   }
   spritePalette.setVisible(spriteColor.getValue())
-  spriteEditor.refresh()
 
+  spriteEditor.refresh()
+  spriteBlend.refresh()
+  
+  let temp = spritePixels;
+  
+  spritePixels = readBytes(spriteBlend, 64)
   clampSpriteData()
-  showHex()
+  showHex(spriteBlend,spritePixels)
+
+  spritePixels = temp
+  clampSpriteData()
+  showHex(spriteEditor,spritePixels)
+
   showSprite()
 }

--- a/js/util.js
+++ b/js/util.js
@@ -54,25 +54,46 @@ function setBit(bytes, n, v) {
   const mask = 128 >> Math.floor(n % 8)
   bytes[Math.floor(n / 8)] = (bytes[Math.floor(n / 8)] & ~mask) | (mask * v)
 }
-function drawOnCanvas(target, body) {
+function drawOnCanvas(target, eventPress, eventRelease=(a,b,c)=>0) {
   var mode = 0
   function drag(event) {
     if (mode == 0) { return }
+    event.preventDefault()
     const r = target.getBoundingClientRect()
-    body(
+    eventPress(
       event.clientX - r.left,
       event.clientY - r.top,
-      mode == 1
+      mode
     )
   }
-  function release(event) { mode = 0; drag(event) }
+  function release(event) {
+    if (mode == 0) { return }
+    event.preventDefault()
+    const r = target.getBoundingClientRect()
+    eventRelease(
+      event.clientX - r.left,
+      event.clientY - r.top,
+      mode
+    )
+    mode = 0
+  }
   function press  (event) { mode = event.button == 2 ? 2 : 1; drag(event) }
   function context(event) { drag(event); return false }
+  function touch(event) {
+    var touches = event.changedTouches
+    event.clientX = touches[0].clientX
+    event.clientY = touches[0].clientY
+    return event
+  }
   target.onmousemove   = drag
   target.onmouseup     = release
   target.onmouseout    = release
   target.onmousedown   = press
   target.oncontextmenu = context
+  target.addEventListener("touchmove",  e=>drag(touch(e)))
+  target.addEventListener("touchstart", e=>press(touch(e)))
+  target.addEventListener("touchend",   e=>release(touch(e)))
+  target.addEventListener("touchcancel",e=>release(touch(e)))
 }
 
 function setVisible(element, value, disp) {


### PR DESCRIPTION
Clean branch of #143 

For the audio editor interface (thanks to @ephphatha for help), the changes are including:

- Pitch selector, in form of clickable piano-key to select desired pitch value according to musical notes
- Better tone generator parameters, by using unit of percentage for duty, and frequency-multiply for pulses
- Frequency monitor to inform the pitch of tone pattern that being generated
- Adding reverse, invert, and clear buttons for the sake of brevity of pattern creation
- Touch swipe support for drawing on the pattern editor, (and the "invert" is handy for undrawing)

For the sprite editor interface, the changes are including:
- Sprite horizontal flip, vertical flip, clockwise rotation, and counter-clockwise rotation transformations
- Sprite color invert, and sprite bitwise blending, for the sake of brevity
- Touch swipe support for drawing on the sprite editor

---
Let me know if there is something needs to be changed before the approval.

[Click here for preview](https://kouzeru.github.io/Octo/)

