### PR TITLE
Link to XO-Chip specs inline

### DIFF
--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -264,7 +264,7 @@ Beyond SuperChip, Octo provides a set of unique extended instructions called XO-
 - `pitch := vx` set the audio pattern playback rate to `4000*2^((vx-64)/48)`Hz. Initialized at 4000Hz.
 - `scroll-up n` scroll the contents of the display up by 0-15 pixels.
 
-For more details, consult the XO-Chip specification in Octo's documentation directory. Octo is the main Chip-8 interpreter which supports these instructions, but a small but growing collection of third-party interpreters support them as well. Why not add them to yours?
+For more details, consult the [XO-Chip specification](XO-ChipSpecification.html) in Octo's documentation directory. Octo is the main Chip-8 interpreter which supports these instructions, but a small but growing collection of third-party interpreters support them as well. Why not add them to yours?
 
 Debugging
 ---------


### PR DESCRIPTION
I find navigating to the docs folder in github from Octo on github pages somewhat annoying, figured a direct link was useful since this doc also gets converted to HTML by github pages.