### PR TITLE
Provide graceful fallback for flag registers if localStorage is unavailable

### DIFF
--- a/index.html
+++ b/index.html
@@ -980,6 +980,12 @@ function runRom(rom) {
   emulator.exitVector = stopRom
   emulator.importFlags = _ => getPref('octoFlagRegisters')
   emulator.exportFlags = f => setPref('octoFlagRegisters',f)
+  try { localStorage.getItem('octoFlagRegisters') }
+  catch(e) {
+    console.warn("Persistent flag register storage is unavailable! Flag registers will not be saved across sessions.")
+    emulator.importFlags = _ => emulator.flags
+    emulator.exportFlags = f => emulator.flags = f
+  }
   emulator.init(rom)
   audioSetup(emulator)
   clearBreakpoint()

--- a/standalone.html
+++ b/standalone.html
@@ -7,6 +7,12 @@ setRenderTarget(data.options.displayScale || 4, 'target')
 emulator.init({rom:data.rom})
 emulator.importFlags = _ => getPref('octoFlagRegisters')
 emulator.exportFlags = f => setPref('octoFlagRegisters',f)
+try { localStorage.getItem('octoFlagRegisters') }
+catch(e) {
+	console.warn("Persistent flag register storage is unavailable! Flag registers will not be saved across sessions.")
+	emulator.importFlags = _ => emulator.flags
+	emulator.exportFlags = f => emulator.flags = f
+}
 emulator.buzzTrigger = (ticks,rest)=> playPattern(ticks, emulator.pattern, rest)
 const kd = e=>{
 	if (!audio) audioSetup(emulator)


### PR DESCRIPTION
Many browsers have introduced the option to block third-party cookies and localStorage use. This can cause use of flag registers to fail ungracefully, zeroing them out.
This change performs a quick check at runtime to see if localStorage is available for the flag registers and if not will dummy out the functions that would attempt this access, allowing regular emulation to proceed without repeated error messages.

Tested working as expected in:
- W11 Chrome 95.0.4638.69 (Official Build) (64-bit)
- W11 Edge 95.0.1020.44 (Official build) (64-bit)
- W11 Firefox 94.0.1 (64-bit)
- Linux Firefox 94.0.1 (64-bit)
- Android Firefox 94.1.2