### PR TITLE
fix: gif decoder local color table typo

### DIFF
--- a/js/sharing.js
+++ b/js/sharing.js
@@ -397,7 +397,7 @@ function gifDecode(bytes) {
 		if (here == 0x3B) break
 		else if (here == 0x2C) {
 			const left = s(), top = s(), iw = s(), ih = s(), ip = b()
-			const lct = (ip & 0x80) ? cl(1 << ((ip & 0x70)+1)) : null
+			const lct = (ip & 0x80) ? cl(1 << ((ip & 0x7)+1)) : null
 			if (ip & 0x40) throw 'interlaced GIFs are not supported.'
 			let pix = unLZW(b(), dl())
 			if (iw != width || ih != height || left!=0 || top!= 0) {


### PR DESCRIPTION
It seem a small typo which makes it fail to load any gifs that has its own local color table

I'm modifying the Octo fork to support 16 colors and palette swapping, and I recorded this gif from it

![recording (43)](https://user-images.githubusercontent.com/46141631/142343681-cfd2f0c4-c78e-45a3-89e4-f3ed3727de66.gif)

It couldn't be loaded on the current vanilla Octo as **cartridge label image** however...

This slight fix would resolve this.


