### PR TITLE
Fix triggered breakpoints showing up under canvas until i key is pressed

### DIFF
--- a/index.html
+++ b/index.html
@@ -609,7 +609,7 @@ input:focus { outline: none; }
 #decompile-cover img { width: 64px; height: 64px; align-self: center; }
 
 #run-cover { flex-direction: column; }
-#run-overlay { position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; }
+#run-overlay { position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; z-index: 1001; }
 #run-controls { margin: 20px; }
 #run-controls img { margin-right: 10px; cursor: pointer; }
 #run-controls img:active { opacity: 0.5; }
@@ -903,7 +903,6 @@ window.onkeyup = event => {
   if (event.key == '`') { stopRom() }
   if (event.key == 'i') {
     emulator.breakpoint ? clearBreakpoint() : haltBreakpoint('user interrupt');
-    var k = document.getElementById("run-overlay").style.zIndex = "1001";
   }
   if (event.key == 'p') { haltProfiler('profiler') }
   if (event.key == 'm') { monitoring = !monitoring; setVisible(document.getElementById('monitor'),monitoring) }


### PR DESCRIPTION
### tl;dr

I fixed the debug view displaying under the game canvas until the user mashes `i`.

### Changes

1. Pin `#run-overlay` to `z-index: 1001` in CSS
2. Remove the redundant & uncached temp fix which ran every time the `i` key was pressed

I could also use custom CSS properties for this, but I wanted to ask before doing so since it would clash with the design choices in the project.

Tested locally on:

- [X] Chromium
- [X] Firefox

### Root cause

1. `#run-cover` and `#decompile-cover` have `.lightbox` classes which set their `z-index` values to 100:
https://github.com/JohnEarnest/Octo/blob/c1b8988cc51f6aa3ce2697b3be3b75c4f0f1bb6e/index.html#L606
2. The canvas has a z-index of 1000:
https://github.com/JohnEarnest/Octo/blob/c1b8988cc51f6aa3ce2697b3be3b75c4f0f1bb6e/index.html#L643

Mashing `i` made the problem look unpredictable since it would vanish for the rest of the browser tab's lifespan due to this code:
https://github.com/JohnEarnest/Octo/blob/c1b8988cc51f6aa3ce2697b3be3b75c4f0f1bb6e/index.html#L904-L906

### Steps to replicate problem 

1. Open a fresh browser tab
6. Navigate to http://johnearnest.github.io/Octo/
7. Open any example
8. Set a breakpoint somewhere in main guaranteed to be hit either, in the UI or with `:breakpoint name`
9. Press run
10. Wait for the breakpoint to be hit
11. The overlay shows up under the canvas
12. Dismissing it will not fix the issue
13. What does work:
      * Pinning a z-index through developer tools
      * Pressing `i` to triggers this line:
https://github.com/JohnEarnest/Octo/blob/5cb8360bd4e57ef077706f3c4c851363149cbc3c/index.html#L906

### Screenshots (Pre-PR)

Chromium
![Screenshot from 2023-11-01 16-11-32](https://github.com/JohnEarnest/Octo/assets/36696816/6fcc1f1f-5e53-4746-a7e2-1d5feb02f834)

Firefox
![image](https://github.com/JohnEarnest/Octo/assets/36696816/2dea0166-1451-4aaa-8faf-a7f28d6c8c93)

